### PR TITLE
fix: allow setting accepted field for new users in db driver

### DIFF
--- a/postgres-driver/load_balancer_test.go
+++ b/postgres-driver/load_balancer_test.go
@@ -145,7 +145,7 @@ func (ts *PGDriverTestSuite) Test_WriteLoadBalancer() {
 				StickyMax:         sql.NullInt32{Valid: true, Int32: 400},
 				Stickiness:        sql.NullBool{Valid: true, Bool: true},
 				Origins:           []string{"chrome-extension://"},
-				Users:             json.RawMessage(`[{"email": "owner4@test.com", "userID": "test_user_47fhsd75jd756sh", "accepted": false, "roleName": "OWNER"}]`),
+				Users:             json.RawMessage(`[{"email": "owner4@test.com", "userID": "test_user_47fhsd75jd756sh", "accepted": true, "roleName": "OWNER"}]`),
 			},
 			err: nil,
 		},

--- a/postgres-driver/query.sql.generated.go
+++ b/postgres-driver/query.sql.generated.go
@@ -33,7 +33,8 @@ func (q *Queries) ActivateBlockchain(ctx context.Context, arg ActivateBlockchain
 
 const deleteUserAccess = `-- name: DeleteUserAccess :exec
 DELETE FROM user_access
-WHERE user_id = $1 AND lb_id = $2
+WHERE user_id = $1
+    AND lb_id = $2
 `
 
 type DeleteUserAccessParams struct {
@@ -514,10 +515,11 @@ INSERT INTO user_access (
         role_name,
         user_id,
         email,
+        accepted,
         created_at,
         updated_at
     )
-VALUES ($1, $2, $3, $4, $5, $6)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 `
 
 type InsertUserAccessParams struct {
@@ -525,6 +527,7 @@ type InsertUserAccessParams struct {
 	RoleName  sql.NullString `json:"roleName"`
 	UserID    sql.NullString `json:"userID"`
 	Email     sql.NullString `json:"email"`
+	Accepted  sql.NullBool   `json:"accepted"`
 	CreatedAt sql.NullTime   `json:"createdAt"`
 	UpdatedAt sql.NullTime   `json:"updatedAt"`
 }
@@ -535,6 +538,7 @@ func (q *Queries) InsertUserAccess(ctx context.Context, arg InsertUserAccessPara
 		arg.RoleName,
 		arg.UserID,
 		arg.Email,
+		arg.Accepted,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)
@@ -1157,7 +1161,7 @@ SELECT lb.lb_id,
     so.stickiness,
     so.origins,
     STRING_AGG(la.app_id, ',') AS app_ids,
-     COALESCE(user_access.ua, '[]') AS users,
+    COALESCE(user_access.ua, '[]') AS users,
     lb.created_at,
     lb.updated_at
 FROM loadbalancers AS lb
@@ -1308,7 +1312,8 @@ const updateUserAccess = `-- name: UpdateUserAccess :exec
 UPDATE user_access as ua
 SET role_name = COALESCE($3, ua.role_name),
     updated_at = $4
-WHERE ua.user_id = $1 AND ua.lb_id = $2
+WHERE ua.user_id = $1
+    AND ua.lb_id = $2
 `
 
 type UpdateUserAccessParams struct {

--- a/postgres-driver/sqlc/query.sql
+++ b/postgres-driver/sqlc/query.sql
@@ -458,7 +458,7 @@ SELECT lb.lb_id,
     so.stickiness,
     so.origins,
     STRING_AGG(la.app_id, ',') AS app_ids,
-     COALESCE(user_access.ua, '[]') AS users,
+    COALESCE(user_access.ua, '[]') AS users,
     lb.created_at,
     lb.updated_at
 FROM loadbalancers AS lb
@@ -531,18 +531,21 @@ INSERT INTO user_access (
         role_name,
         user_id,
         email,
+        accepted,
         created_at,
         updated_at
     )
-VALUES ($1, $2, $3, $4, $5, $6);
+VALUES ($1, $2, $3, $4, $5, $6, $7);
 -- name: UpdateUserAccess :exec
 UPDATE user_access as ua
 SET role_name = COALESCE($3, ua.role_name),
     updated_at = $4
-WHERE ua.user_id = $1 AND ua.lb_id = $2;
+WHERE ua.user_id = $1
+    AND ua.lb_id = $2;
 -- name: DeleteUserAccess :exec
 DELETE FROM user_access
-WHERE user_id = $1 AND lb_id = $2;
+WHERE user_id = $1
+    AND lb_id = $2;
 -- name: UpsertStickinessOptions :exec
 INSERT INTO stickiness_options AS so (
         lb_id,

--- a/postgres-driver/sqlc/schema.sql
+++ b/postgres-driver/sqlc/schema.sql
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS user_access (
 	user_id VARCHAR,
 	role_name VARCHAR,
 	email VARCHAR,
-	accepted BOOLEAN DEFAULT false,
+	accepted BOOLEAN,
 	created_at TIMESTAMP NULL,
 	updated_at TIMESTAMP NULL,
 	PRIMARY KEY (id),


### PR DESCRIPTION
This PR updates the postgres driver to allow setting the accepted field in the insert user access query instead of defaulting it to false.

This is because, when creating a new LB, the creator of the LB will becomes its first user with the OWNER role and thus should be automatically accepted instead of having to accept manually.