### PR TITLE
feat: T-17772 updated driver to work with single row scalable whitelist entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 bin
 
 pre-commit-2.20.0.pyz
+test.json

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ gen_mocks:
 
 test: test_env_up run_driver_tests test_env_down
 test_env_up:
-	docker-compose -f ./docker-compose.test.yml up -d --remove-orphans;
+	docker-compose -f ./docker-compose.test.yml up -d --remove-orphans --build;
 	sleep 2;
 test_env_down:
 	docker-compose -f ./docker-compose.test.yml down --remove-orphans -v

--- a/postgres-driver/application.go
+++ b/postgres-driver/application.go
@@ -2,8 +2,8 @@ package postgresdriver
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
@@ -19,14 +19,27 @@ func (p *PostgresDriver) ReadApplications(ctx context.Context) ([]*types.Applica
 
 	var applications []*types.Application
 	for _, dbApplication := range dbApplications {
-		applications = append(applications, dbApplication.toApplication())
+		application, err := dbApplication.toApplication()
+		if err != nil {
+			return nil, err
+		}
+
+		applications = append(applications, application)
 	}
 
 	return applications, nil
-
 }
 
-func (a *SelectApplicationsRow) toApplication() *types.Application {
+func (a *SelectApplicationsRow) toApplication() (*types.Application, error) {
+	whitelistContractsJSON, err := stringToWhitelistContracts(toString(a.WhitelistContracts))
+	if err != nil {
+		return nil, err
+	}
+	whitelistMethodsJSON, err := stringToWhitelistMethods(toString(a.WhitelistMethods))
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.Application{
 		ID:                 a.ApplicationID,
 		UserID:             a.UserID.String,
@@ -51,8 +64,8 @@ func (a *SelectApplicationsRow) toApplication() *types.Application {
 			SecretKey:            a.SecretKey.String,
 			SecretKeyRequired:    a.SecretKeyRequired.Bool,
 			WhitelistBlockchains: a.WhitelistBlockchains,
-			WhitelistContracts:   stringToWhitelistContracts(fmt.Sprintf("%v", a.WhitelistContracts)),
-			WhitelistMethods:     stringToWhitelistMethods(fmt.Sprintf("%v", a.WhitelistMethods)),
+			WhitelistContracts:   whitelistContractsJSON,
+			WhitelistMethods:     whitelistMethodsJSON,
 			WhitelistOrigins:     a.WhitelistOrigins,
 			WhitelistUserAgents:  a.WhitelistUserAgents,
 		},
@@ -72,17 +85,20 @@ func (a *SelectApplicationsRow) toApplication() *types.Application {
 		},
 		CreatedAt: a.CreatedAt.Time,
 		UpdatedAt: a.UpdatedAt.Time,
-	}
+	}, nil
 }
 
-func stringToWhitelistContracts(rawContracts string) []types.WhitelistContract {
-	var contracts []types.WhitelistContract
+func stringToWhitelistContracts(rawContracts string) ([]types.WhitelistContracts, error) {
+	var contracts []types.WhitelistContracts
 
 	if rawContracts == "" {
-		return contracts
+		return contracts, nil
 	}
 
-	_ = json.Unmarshal([]byte(rawContracts), &contracts)
+	err := json.Unmarshal([]byte(rawContracts), &contracts)
+	if err != nil {
+		return nil, err
+	}
 
 	for i, contract := range contracts {
 		for j, inContract := range contract.Contracts {
@@ -90,17 +106,20 @@ func stringToWhitelistContracts(rawContracts string) []types.WhitelistContract {
 		}
 	}
 
-	return contracts
+	return contracts, nil
 }
 
-func stringToWhitelistMethods(rawMethods string) []types.WhitelistMethod {
-	var methods []types.WhitelistMethod
+func stringToWhitelistMethods(rawMethods string) ([]types.WhitelistMethods, error) {
+	var methods []types.WhitelistMethods
 
 	if rawMethods == "" {
-		return methods
+		return methods, nil
 	}
 
-	_ = json.Unmarshal([]byte(rawMethods), &methods)
+	err := json.Unmarshal([]byte(rawMethods), &methods)
+	if err != nil {
+		return nil, err
+	}
 
 	for i, method := range methods {
 		for j, inMethod := range method.Methods {
@@ -108,7 +127,7 @@ func stringToWhitelistMethods(rawMethods string) []types.WhitelistMethod {
 		}
 	}
 
-	return methods
+	return methods, nil
 }
 
 /* ReadPayPlans returns all pay plans in the database and marshals to types struct */
@@ -313,23 +332,27 @@ func (p *PostgresDriver) UpdateApplication(ctx context.Context, id string, updat
 			return err
 		}
 	}
+
 	for _, contract := range update.GatewaySettings.WhitelistContracts {
-		whitelistContractParams := extractUpsertWhitelistContracts(id, &contract)
-		if whitelistContractParams != nil {
-			err = qtx.UpsertWhitelistContracts(ctx, *whitelistContractParams)
-			if err != nil {
-				return err
-			}
+		err = qtx.UpdateWhitelistContracts(ctx, extractUpdateWhitelistContracts(id, &contract))
+		if err != nil {
+			return err
 		}
 	}
+	err = qtx.DeleteNotPresentWhitelistContracts(ctx, extractDeleteWhitelistContracts(id, update.GatewaySettings.WhitelistContracts))
+	if err != nil {
+		return err
+	}
+
 	for _, method := range update.GatewaySettings.WhitelistMethods {
-		whitelistMethodParams := extractUpsertWhitelistMethods(id, &method)
-		if whitelistMethodParams != nil {
-			err = qtx.UpsertWhitelistMethods(ctx, *whitelistMethodParams)
-			if err != nil {
-				return err
-			}
+		err = qtx.UpdateWhitelistMethods(ctx, extractUpdateWhitelistMethods(id, &method))
+		if err != nil {
+			return err
 		}
+	}
+	err = qtx.DeleteNotPresentWhitelistMethods(ctx, extractDeleteWhitelistMethods(id, update.GatewaySettings.WhitelistMethods))
+	if err != nil {
+		return err
 	}
 
 	notificationSettingsParams := extractUpsertNotificationSettings(id, update)
@@ -396,27 +419,49 @@ func (u *UpsertGatewaySettingsParams) isNotNull() bool {
 		len(u.WhitelistOrigins) != 0 || len(u.WhitelistUserAgents) != 0 || len(u.WhitelistBlockchains) != 0)
 }
 
-func extractUpsertWhitelistContracts(id string, updateContract *types.WhitelistContract) *UpsertWhitelistContractsParams {
-	if len(updateContract.Contracts) == 0 {
-		return nil
-	}
-
-	return &UpsertWhitelistContractsParams{
+func extractUpdateWhitelistContracts(id string, updateContract *types.WhitelistContracts) UpdateWhitelistContractsParams {
+	return UpdateWhitelistContractsParams{
 		ApplicationID: id,
-		BlockchainID:  updateContract.BlockchainID,
+		BlockchainID:  sql.NullString{Valid: true, String: updateContract.BlockchainID},
 		Contracts:     updateContract.Contracts,
 	}
 }
 
-func extractUpsertWhitelistMethods(id string, updateContract *types.WhitelistMethod) *UpsertWhitelistMethodsParams {
-	if len(updateContract.Methods) == 0 {
-		return nil
+func extractDeleteWhitelistContracts(id string, updateContracts []types.WhitelistContracts) DeleteNotPresentWhitelistContractsParams {
+	blockchainIDs := []string{}
+
+	for _, contract := range updateContracts {
+		if len(updateContracts) > 0 {
+			blockchainIDs = append(blockchainIDs, contract.BlockchainID)
+		}
 	}
 
-	return &UpsertWhitelistMethodsParams{
+	return DeleteNotPresentWhitelistContractsParams{
 		ApplicationID: id,
-		BlockchainID:  updateContract.BlockchainID,
-		Methods:       updateContract.Methods,
+		BlockchainIds: blockchainIDs,
+	}
+}
+
+func extractUpdateWhitelistMethods(id string, updateMethod *types.WhitelistMethods) UpdateWhitelistMethodsParams {
+	return UpdateWhitelistMethodsParams{
+		ApplicationID: id,
+		BlockchainID:  sql.NullString{Valid: true, String: updateMethod.BlockchainID},
+		Methods:       updateMethod.Methods,
+	}
+}
+
+func extractDeleteWhitelistMethods(id string, updateMethods []types.WhitelistMethods) DeleteNotPresentWhitelistMethodsParams {
+	blockchainIDs := []string{}
+
+	for _, method := range updateMethods {
+		if len(updateMethods) > 0 {
+			blockchainIDs = append(blockchainIDs, method.BlockchainID)
+		}
+	}
+
+	return DeleteNotPresentWhitelistMethodsParams{
+		ApplicationID: id,
+		BlockchainIds: blockchainIDs,
 	}
 }
 
@@ -511,14 +556,14 @@ type (
 		WhitelistBlockchains []string `json:"whitelist_blockchains"`
 	}
 	dbWhitelistContractJSON struct {
-		ApplicationID string   `json:"application_id"`
-		BlockchainID  string   `json:"blockchain_id"`
-		Contracts     []string `json:"contracts"`
+		ApplicationID string `json:"application_id"`
+		BlockchainID  string `json:"blockchain_id"`
+		Contract      string `json:"contract"`
 	}
 	dbWhitelistMethodJSON struct {
-		ApplicationID string   `json:"application_id"`
-		BlockchainID  string   `json:"blockchain_id"`
-		Methods       []string `json:"methods"`
+		ApplicationID string `json:"application_id"`
+		BlockchainID  string `json:"blockchain_id"`
+		Method        string `json:"method"`
 	}
 	dbNotificationSettingsJSON struct {
 		ApplicationID string `json:"application_id"`
@@ -580,14 +625,14 @@ func (j dbWhitelistContractJSON) toOutput() *types.WhitelistContract {
 	return &types.WhitelistContract{
 		ID:           j.ApplicationID,
 		BlockchainID: j.BlockchainID,
-		Contracts:    j.Contracts,
+		Contract:     j.Contract,
 	}
 }
 func (j dbWhitelistMethodJSON) toOutput() *types.WhitelistMethod {
 	return &types.WhitelistMethod{
 		ID:           j.ApplicationID,
 		BlockchainID: j.BlockchainID,
-		Methods:      j.Methods,
+		Method:       j.Method,
 	}
 }
 func (j dbNotificationSettingsJSON) toOutput() *types.NotificationSettings {

--- a/postgres-driver/application_test.go
+++ b/postgres-driver/application_test.go
@@ -31,8 +31,19 @@ func (ts *PGDriverTestSuite) Test_ReadApplications() {
 						PrivateKey:           "test_d2ce53f115f4ecb2208e9188800a85cf",
 					},
 					GatewaySettings: types.GatewaySettings{
-						SecretKey:         "test_40f482d91a5ef2300ebb4e2308c",
-						SecretKeyRequired: true,
+						SecretKey:            "test_40f482d91a5ef2300ebb4e2308c",
+						SecretKeyRequired:    true,
+						WhitelistBlockchains: []string{"chain_1"},
+						WhitelistOrigins:     []string{"origin_1", "origin_2"},
+						WhitelistUserAgents:  []string{"user_agent_1", "user_agent_2", "user_agent_3"},
+						WhitelistContracts: []types.WhitelistContracts{
+							{BlockchainID: "TST2", Contracts: []string{"test_address_67890"}},
+							{BlockchainID: "TST1", Contracts: []string{"test_address_12345", "test_address_44444"}},
+						},
+						WhitelistMethods: []types.WhitelistMethods{
+							{BlockchainID: "TST1", Methods: []string{"GET"}},
+							{BlockchainID: "TST2", Methods: []string{"PUT", "POST"}},
+						},
 					},
 					Limit: types.AppLimit{
 						PayPlan: types.PayPlan{Type: types.FreetierV0, Limit: 250_000},
@@ -282,13 +293,13 @@ func (ts *PGDriverTestSuite) Test_UpdateApplication() {
 				GatewaySettings: &types.UpdateGatewaySettings{
 					WhitelistOrigins:    []string{"test-origin1", "test-origin2"},
 					WhitelistUserAgents: []string{"test-agent1"},
-					WhitelistContracts: []types.WhitelistContract{
+					WhitelistContracts: []types.WhitelistContracts{
 						{
 							BlockchainID: "01",
 							Contracts:    []string{"test-contract1"},
 						},
 					},
-					WhitelistMethods: []types.WhitelistMethod{
+					WhitelistMethods: []types.WhitelistMethods{
 						{
 							BlockchainID: "01",
 							Methods:      []string{"test-method1"},
@@ -313,8 +324,8 @@ func (ts *PGDriverTestSuite) Test_UpdateApplication() {
 			expectedAfterUpdate: SelectOneApplicationRow{
 				Name:                 sql.NullString{Valid: true, String: "pokt_app_updated_lb"},
 				WhitelistBlockchains: []string{"test-chain1"},
-				WhitelistContracts:   "[{\"blockchain_id\" : \"01\", \"contracts\" : [\"test-contract1\"]}]",
-				WhitelistMethods:     "[{\"blockchain_id\" : \"01\", \"methods\" : [\"test-method1\"]}]",
+				WhitelistContracts:   "[{\"contracts\": [\"test-contract1\"], \"blockchainID\": \"01\"}]",
+				WhitelistMethods:     "[{\"methods\": [\"test-method1\"], \"blockchainID\": \"01\"}]",
 				WhitelistOrigins:     []string{"test-origin1", "test-origin2"},
 				WhitelistUserAgents:  []string{"test-agent1"},
 				SignedUp:             sql.NullBool{Valid: true, Bool: false},
@@ -347,6 +358,94 @@ func (ts *PGDriverTestSuite) Test_UpdateApplication() {
 				WhitelistBlockchains: []string(nil),
 				WhitelistOrigins:     []string{"test-origin1", "test-origin2"},
 				WhitelistUserAgents:  []string{"test-agent1"},
+				SignedUp:             sql.NullBool{Valid: true, Bool: true},
+				OnQuarter:            sql.NullBool{Valid: true, Bool: false},
+				OnHalf:               sql.NullBool{Valid: true, Bool: false},
+				OnThreeQuarters:      sql.NullBool{Valid: true, Bool: true},
+				OnFull:               sql.NullBool{Valid: true, Bool: false},
+				CustomLimit:          sql.NullInt32{Valid: true, Int32: 0},
+				PayPlan:              sql.NullString{Valid: true, String: "PAY_AS_YOU_GO_V0"},
+			},
+			err: nil,
+		},
+		{
+			name:  "Should add whitelist contracts & methods",
+			appID: "test_app_5hdf7sh23jd828",
+			appUpdate: &types.UpdateApplication{
+				GatewaySettings: &types.UpdateGatewaySettings{
+					WhitelistContracts: []types.WhitelistContracts{
+						{
+							BlockchainID: "01",
+							Contracts:    []string{"test-contract1", "test-contract2"},
+						},
+						{
+							BlockchainID: "02",
+							Contracts:    []string{"test-contract3", "test-contract4"},
+						},
+					},
+					WhitelistMethods: []types.WhitelistMethods{
+						{
+							BlockchainID: "01",
+							Methods:      []string{"test-method1", "test-method2", "test-method3"},
+						},
+						{
+							BlockchainID: "03",
+							Methods:      []string{"test-method4", "test-method5", "test-method6"},
+						},
+					},
+				},
+			},
+			expectedAfterUpdate: SelectOneApplicationRow{
+				Name:                 sql.NullString{Valid: true, String: "pokt_app_456"},
+				WhitelistBlockchains: []string(nil),
+				WhitelistOrigins:     []string{"test-origin1", "test-origin2"},
+				WhitelistUserAgents:  []string{"test-agent1"},
+				WhitelistContracts:   "[{\"contracts\": [\"test-contract1\", \"test-contract2\"], \"blockchainID\": \"01\"}, {\"contracts\": [\"test-contract3\", \"test-contract4\"], \"blockchainID\": \"02\"}]",
+				WhitelistMethods:     "[{\"methods\": [\"test-method1\", \"test-method2\", \"test-method3\"], \"blockchainID\": \"01\"}, {\"methods\": [\"test-method4\", \"test-method5\", \"test-method6\"], \"blockchainID\": \"03\"}]",
+				SignedUp:             sql.NullBool{Valid: true, Bool: true},
+				OnQuarter:            sql.NullBool{Valid: true, Bool: false},
+				OnHalf:               sql.NullBool{Valid: true, Bool: false},
+				OnThreeQuarters:      sql.NullBool{Valid: true, Bool: true},
+				OnFull:               sql.NullBool{Valid: true, Bool: false},
+				CustomLimit:          sql.NullInt32{Valid: true, Int32: 0},
+				PayPlan:              sql.NullString{Valid: true, String: "PAY_AS_YOU_GO_V0"},
+			},
+			err: nil,
+		},
+		{
+			name:  "Should remove whitelist contracts & methods",
+			appID: "test_app_5hdf7sh23jd828",
+			appUpdate: &types.UpdateApplication{
+				GatewaySettings: &types.UpdateGatewaySettings{
+					WhitelistContracts: []types.WhitelistContracts{
+						{
+							BlockchainID: "01",
+							Contracts:    []string{"test-contract2"},
+						},
+						{
+							BlockchainID: "02",
+							Contracts:    []string{},
+						},
+					},
+					WhitelistMethods: []types.WhitelistMethods{
+						{
+							BlockchainID: "01",
+							Methods:      []string{"test-method1"},
+						},
+						{
+							BlockchainID: "03",
+							Methods:      []string{"test-method5", "test-method6"},
+						},
+					},
+				},
+			},
+			expectedAfterUpdate: SelectOneApplicationRow{
+				Name:                 sql.NullString{Valid: true, String: "pokt_app_456"},
+				WhitelistBlockchains: []string(nil),
+				WhitelistOrigins:     []string{"test-origin1", "test-origin2"},
+				WhitelistUserAgents:  []string{"test-agent1"},
+				WhitelistContracts:   "[{\"contracts\": [\"test-contract2\"], \"blockchainID\": \"01\"}]",
+				WhitelistMethods:     "[{\"methods\": [\"test-method1\"], \"blockchainID\": \"01\"}, {\"methods\": [\"test-method5\", \"test-method6\"], \"blockchainID\": \"03\"}]",
 				SignedUp:             sql.NullBool{Valid: true, Bool: true},
 				OnQuarter:            sql.NullBool{Valid: true, Bool: false},
 				OnHalf:               sql.NullBool{Valid: true, Bool: false},

--- a/postgres-driver/listener_mock.go
+++ b/postgres-driver/listener_mock.go
@@ -97,27 +97,31 @@ func applicationInputs(mainTableAction, sideTablesAction types.Action, content t
 				WhitelistBlockchains: app.GatewaySettings.WhitelistBlockchains,
 			},
 		})
-		for _, contract := range app.GatewaySettings.WhitelistContracts {
-			inputs = append(inputs, inputStruct{
-				action: sideTablesAction,
-				table:  types.TableWhitelistContracts,
-				input: dbWhitelistContractJSON{
-					ApplicationID: app.ID,
-					BlockchainID:  contract.BlockchainID,
-					Contracts:     contract.Contracts,
-				},
-			})
+		for _, contracts := range app.GatewaySettings.WhitelistContracts {
+			for _, contract := range contracts.Contracts {
+				inputs = append(inputs, inputStruct{
+					action: sideTablesAction,
+					table:  types.TableWhitelistContracts,
+					input: dbWhitelistContractJSON{
+						ApplicationID: app.ID,
+						BlockchainID:  contracts.BlockchainID,
+						Contract:      contract,
+					},
+				})
+			}
 		}
-		for _, method := range app.GatewaySettings.WhitelistMethods {
-			inputs = append(inputs, inputStruct{
-				action: sideTablesAction,
-				table:  types.TableWhitelistMethods,
-				input: dbWhitelistMethodJSON{
-					ApplicationID: app.ID,
-					BlockchainID:  method.BlockchainID,
-					Methods:       method.Methods,
-				},
-			})
+		for _, methods := range app.GatewaySettings.WhitelistMethods {
+			for _, method := range methods.Methods {
+				inputs = append(inputs, inputStruct{
+					action: sideTablesAction,
+					table:  types.TableWhitelistMethods,
+					input: dbWhitelistMethodJSON{
+						ApplicationID: app.ID,
+						BlockchainID:  methods.BlockchainID,
+						Method:        method,
+					},
+				})
+			}
 		}
 	}
 

--- a/postgres-driver/listener_test.go
+++ b/postgres-driver/listener_test.go
@@ -25,10 +25,10 @@ func TestListen(t *testing.T) {
 				GatewaySettings: types.GatewaySettings{
 					SecretKey:            "123",
 					WhitelistBlockchains: []string{"test-chain-1", "test-chain-2"},
-					WhitelistContracts: []types.WhitelistContract{
-						{BlockchainID: "001", Contracts: []string{"test123", "test456"}},
+					WhitelistContracts: []types.WhitelistContracts{
+						{BlockchainID: "001", Contracts: []string{"test123"}},
 					},
-					WhitelistMethods: []types.WhitelistMethod{
+					WhitelistMethods: []types.WhitelistMethods{
 						{BlockchainID: "001", Methods: []string{"POST"}},
 					},
 				},
@@ -78,14 +78,14 @@ func TestListen(t *testing.T) {
 					Table:  types.TableWhitelistContracts,
 					Action: types.ActionUpdate,
 					Data: &types.WhitelistContract{
-						ID: "321", BlockchainID: "001", Contracts: []string{"test123", "test456"},
+						ID: "321", BlockchainID: "001", Contract: "test123",
 					},
 				},
 				types.TableWhitelistMethods: {
 					Table:  types.TableWhitelistMethods,
 					Action: types.ActionUpdate,
 					Data: &types.WhitelistMethod{
-						ID: "321", BlockchainID: "001", Methods: []string{"POST"},
+						ID: "321", BlockchainID: "001", Method: "POST",
 					},
 				},
 				types.TableNotificationSettings: {

--- a/postgres-driver/models.generated.go
+++ b/postgres-driver/models.generated.go
@@ -206,12 +206,12 @@ type WhitelistContract struct {
 	ID            int32          `json:"id"`
 	ApplicationID string         `json:"applicationID"`
 	BlockchainID  sql.NullString `json:"blockchainID"`
-	Contracts     []string       `json:"contracts"`
+	Contract      sql.NullString `json:"contract"`
 }
 
 type WhitelistMethod struct {
 	ID            int32          `json:"id"`
 	ApplicationID string         `json:"applicationID"`
 	BlockchainID  sql.NullString `json:"blockchainID"`
-	Methods       []string       `json:"methods"`
+	Method        sql.NullString `json:"method"`
 }

--- a/postgres-driver/postgresdriver.go
+++ b/postgres-driver/postgresdriver.go
@@ -138,3 +138,11 @@ func psqlDateToTime(rawDate string) time.Time {
 func boolPointer(value bool) *bool {
 	return &value
 }
+
+// Typeguard for a derived field from Postgres that must be either nil or a string
+func toString(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	return v.(string)
+}

--- a/postgres-driver/query.sql.generated.go
+++ b/postgres-driver/query.sql.generated.go
@@ -32,6 +32,40 @@ func (q *Queries) ActivateBlockchain(ctx context.Context, arg ActivateBlockchain
 	return err
 }
 
+const deleteNotPresentWhitelistContracts = `-- name: DeleteNotPresentWhitelistContracts :exec
+DELETE FROM whitelist_contracts
+WHERE application_id = $1 AND blockchain_id NOT IN (
+   SELECT unnest($2::VARCHAR[])
+)
+`
+
+type DeleteNotPresentWhitelistContractsParams struct {
+	ApplicationID string   `json:"applicationID"`
+	BlockchainIds []string `json:"blockchainIds"`
+}
+
+func (q *Queries) DeleteNotPresentWhitelistContracts(ctx context.Context, arg DeleteNotPresentWhitelistContractsParams) error {
+	_, err := q.db.ExecContext(ctx, deleteNotPresentWhitelistContracts, arg.ApplicationID, pq.Array(arg.BlockchainIds))
+	return err
+}
+
+const deleteNotPresentWhitelistMethods = `-- name: DeleteNotPresentWhitelistMethods :exec
+DELETE FROM whitelist_methods
+WHERE application_id = $1 AND blockchain_id NOT IN (
+   SELECT unnest($2::VARCHAR[])
+)
+`
+
+type DeleteNotPresentWhitelistMethodsParams struct {
+	ApplicationID string   `json:"applicationID"`
+	BlockchainIds []string `json:"blockchainIds"`
+}
+
+func (q *Queries) DeleteNotPresentWhitelistMethods(ctx context.Context, arg DeleteNotPresentWhitelistMethodsParams) error {
+	_, err := q.db.ExecContext(ctx, deleteNotPresentWhitelistMethods, arg.ApplicationID, pq.Array(arg.BlockchainIds))
+	return err
+}
+
 const deleteUserAccess = `-- name: DeleteUserAccess :exec
 DELETE FROM user_access
 WHERE user_id = $1
@@ -254,11 +288,7 @@ INSERT into gateway_settings (
         secret_key,
         secret_key_required
     )
-VALUES (
-        $1,
-        $2,
-        $3
-    )
+VALUES ($1, $2, $3)
 `
 
 type InsertGatewaySettingsParams struct {
@@ -577,13 +607,6 @@ func (q *Queries) SelectAppLimit(ctx context.Context, applicationID string) (Sel
 }
 
 const selectApplications = `-- name: SelectApplications :many
-WITH app_whitelists AS (
-    SELECT application_id
-    FROM whitelist_contracts
-    UNION
-    SELECT application_id
-    FROM whitelist_methods
-)
 SELECT a.application_id,
     a.contact_email,
     a.created_at,
@@ -607,6 +630,29 @@ SELECT a.application_id,
     gs.whitelist_blockchains,
     gs.whitelist_origins,
     gs.whitelist_user_agents,
+    CASE
+        WHEN wc.application_id IS NOT NULL THEN json_agg(
+            DISTINCT jsonb_build_object(
+                'blockchainID',
+                wc.blockchain_id,
+                'contracts',
+                wc.contracts
+            )
+        )::VARCHAR
+        ELSE NULL
+    END as whitelist_contracts,
+    CASE
+        WHEN wm.application_id IS NOT NULL THEN json_agg(
+            DISTINCT jsonb_build_object(
+                'blockchainID',
+                wm.blockchain_id,
+                'methods',
+                wm.methods
+            )
+        )::VARCHAR
+        ELSE NULL
+    END as whitelist_methods,
+    ns.signed_up,
     ns.signed_up,
     ns.on_quarter,
     ns.on_half,
@@ -614,49 +660,30 @@ SELECT a.application_id,
     ns.on_full,
     al.custom_limit,
     al.pay_plan,
-    pp.daily_limit as plan_limit,
-    CASE
-        WHEN wc.application_id IS NOT NULL THEN json_agg(
-            json_build_object(
-                'blockchain_id',
-                wc.blockchain_id,
-                'contracts',
-                wc.contracts
-            )
-        )::VARCHAR
-        ELSE null
-    END as whitelist_contracts,
-    CASE
-        WHEN wm.application_id IS NOT NULL THEN json_agg(
-            json_build_object(
-                'blockchain_id',
-                wm.blockchain_id,
-                'methods',
-                wm.methods
-            )
-        )::VARCHAR
-        ELSE null
-    END as whitelist_methods
+    pp.daily_limit as plan_limit
 FROM applications AS a
     LEFT JOIN gateway_aat AS ga ON a.application_id = ga.application_id
     LEFT JOIN gateway_settings AS gs ON a.application_id = gs.application_id
     LEFT JOIN notification_settings AS ns ON a.application_id = ns.application_id
     LEFT JOIN app_limits AS al ON a.application_id = al.application_id
     LEFT JOIN pay_plans AS pp ON al.pay_plan = pp.plan_type
-    LEFT JOIN whitelist_contracts wc ON a.application_id = wc.application_id
-    LEFT JOIN whitelist_methods wm ON a.application_id = wm.application_id
+    LEFT JOIN (
+        SELECT application_id,
+            blockchain_id,
+            json_agg(contract) AS contracts
+        FROM whitelist_contracts
+        GROUP BY application_id,
+            blockchain_id
+    ) wc ON a.application_id = wc.application_id
+    LEFT JOIN (
+        SELECT application_id,
+            blockchain_id,
+            json_agg(method) AS methods
+        FROM whitelist_methods
+        GROUP BY application_id,
+            blockchain_id
+    ) wm ON a.application_id = wm.application_id
 GROUP BY a.application_id,
-    a.contact_email,
-    a.created_at,
-    a.description,
-    a.dummy,
-    a.name,
-    a.owner,
-    a.status,
-    a.updated_at,
-    a.url,
-    a.user_id,
-    a.first_date_surpassed,
     ga.address,
     ga.client_public_key,
     ga.private_key,
@@ -704,7 +731,10 @@ type SelectApplicationsRow struct {
 	WhitelistBlockchains []string       `json:"whitelistBlockchains"`
 	WhitelistOrigins     []string       `json:"whitelistOrigins"`
 	WhitelistUserAgents  []string       `json:"whitelistUserAgents"`
+	WhitelistContracts   interface{}    `json:"whitelistContracts"`
+	WhitelistMethods     interface{}    `json:"whitelistMethods"`
 	SignedUp             sql.NullBool   `json:"signedUp"`
+	SignedUp_2           sql.NullBool   `json:"signedUp2"`
 	OnQuarter            sql.NullBool   `json:"onQuarter"`
 	OnHalf               sql.NullBool   `json:"onHalf"`
 	OnThreeQuarters      sql.NullBool   `json:"onThreeQuarters"`
@@ -712,8 +742,6 @@ type SelectApplicationsRow struct {
 	CustomLimit          sql.NullInt32  `json:"customLimit"`
 	PayPlan              sql.NullString `json:"payPlan"`
 	PlanLimit            sql.NullInt32  `json:"planLimit"`
-	WhitelistContracts   interface{}    `json:"whitelistContracts"`
-	WhitelistMethods     interface{}    `json:"whitelistMethods"`
 }
 
 func (q *Queries) SelectApplications(ctx context.Context) ([]SelectApplicationsRow, error) {
@@ -749,7 +777,10 @@ func (q *Queries) SelectApplications(ctx context.Context) ([]SelectApplicationsR
 			pq.Array(&i.WhitelistBlockchains),
 			pq.Array(&i.WhitelistOrigins),
 			pq.Array(&i.WhitelistUserAgents),
+			&i.WhitelistContracts,
+			&i.WhitelistMethods,
 			&i.SignedUp,
+			&i.SignedUp_2,
 			&i.OnQuarter,
 			&i.OnHalf,
 			&i.OnThreeQuarters,
@@ -757,8 +788,6 @@ func (q *Queries) SelectApplications(ctx context.Context) ([]SelectApplicationsR
 			&i.CustomLimit,
 			&i.PayPlan,
 			&i.PlanLimit,
-			&i.WhitelistContracts,
-			&i.WhitelistMethods,
 		); err != nil {
 			return nil, err
 		}
@@ -1083,13 +1112,6 @@ func (q *Queries) SelectNotificationSettings(ctx context.Context, applicationID 
 }
 
 const selectOneApplication = `-- name: SelectOneApplication :one
-WITH app_whitelists AS (
-    SELECT application_id
-    FROM whitelist_contracts
-    UNION
-    SELECT application_id
-    FROM whitelist_methods
-)
 SELECT a.application_id,
     a.contact_email,
     a.created_at,
@@ -1113,6 +1135,28 @@ SELECT a.application_id,
     gs.whitelist_blockchains,
     gs.whitelist_origins,
     gs.whitelist_user_agents,
+    CASE
+        WHEN wc.application_id IS NOT NULL THEN json_agg(
+            DISTINCT jsonb_build_object(
+                'blockchainID',
+                wc.blockchain_id,
+                'contracts',
+                wc.contracts
+            )
+        )::VARCHAR
+        ELSE NULL
+    END as whitelist_contracts,
+    CASE
+        WHEN wm.application_id IS NOT NULL THEN json_agg(
+            DISTINCT jsonb_build_object(
+                'blockchainID',
+                wm.blockchain_id,
+                'methods',
+                wm.methods
+            )
+        )::VARCHAR
+        ELSE NULL
+    END as whitelist_methods,
     ns.signed_up,
     ns.on_quarter,
     ns.on_half,
@@ -1120,50 +1164,31 @@ SELECT a.application_id,
     ns.on_full,
     al.custom_limit,
     al.pay_plan,
-    pp.daily_limit as plan_limit,
-    CASE
-        WHEN wc.application_id IS NOT NULL THEN json_agg(
-            json_build_object(
-                'blockchain_id',
-                wc.blockchain_id,
-                'contracts',
-                wc.contracts
-            )
-        )::VARCHAR
-        ELSE null
-    END as whitelist_contracts,
-    CASE
-        WHEN wm.application_id IS NOT NULL THEN json_agg(
-            json_build_object(
-                'blockchain_id',
-                wm.blockchain_id,
-                'methods',
-                wm.methods
-            )
-        )::VARCHAR
-        ELSE null
-    END as whitelist_methods
+    pp.daily_limit as plan_limit
 FROM applications AS a
     LEFT JOIN gateway_aat AS ga ON a.application_id = ga.application_id
     LEFT JOIN gateway_settings AS gs ON a.application_id = gs.application_id
     LEFT JOIN notification_settings AS ns ON a.application_id = ns.application_id
     LEFT JOIN app_limits AS al ON a.application_id = al.application_id
     LEFT JOIN pay_plans AS pp ON al.pay_plan = pp.plan_type
-    LEFT JOIN whitelist_contracts wc ON a.application_id = wc.application_id
-    LEFT JOIN whitelist_methods wm ON a.application_id = wm.application_id
+    LEFT JOIN (
+        SELECT application_id,
+            blockchain_id,
+            json_agg(contract) AS contracts
+        FROM whitelist_contracts
+        GROUP BY application_id,
+            blockchain_id
+    ) wc ON a.application_id = wc.application_id
+    LEFT JOIN (
+        SELECT application_id,
+            blockchain_id,
+            json_agg(method) AS methods
+        FROM whitelist_methods
+        GROUP BY application_id,
+            blockchain_id
+    ) wm ON a.application_id = wm.application_id
 WHERE a.application_id = $1
 GROUP BY a.application_id,
-    a.contact_email,
-    a.created_at,
-    a.description,
-    a.dummy,
-    a.name,
-    a.owner,
-    a.status,
-    a.updated_at,
-    a.url,
-    a.user_id,
-    a.first_date_surpassed,
     ga.address,
     ga.client_public_key,
     ga.private_key,
@@ -1211,6 +1236,8 @@ type SelectOneApplicationRow struct {
 	WhitelistBlockchains []string       `json:"whitelistBlockchains"`
 	WhitelistOrigins     []string       `json:"whitelistOrigins"`
 	WhitelistUserAgents  []string       `json:"whitelistUserAgents"`
+	WhitelistContracts   interface{}    `json:"whitelistContracts"`
+	WhitelistMethods     interface{}    `json:"whitelistMethods"`
 	SignedUp             sql.NullBool   `json:"signedUp"`
 	OnQuarter            sql.NullBool   `json:"onQuarter"`
 	OnHalf               sql.NullBool   `json:"onHalf"`
@@ -1219,8 +1246,6 @@ type SelectOneApplicationRow struct {
 	CustomLimit          sql.NullInt32  `json:"customLimit"`
 	PayPlan              sql.NullString `json:"payPlan"`
 	PlanLimit            sql.NullInt32  `json:"planLimit"`
-	WhitelistContracts   interface{}    `json:"whitelistContracts"`
-	WhitelistMethods     interface{}    `json:"whitelistMethods"`
 }
 
 func (q *Queries) SelectOneApplication(ctx context.Context, applicationID string) (SelectOneApplicationRow, error) {
@@ -1250,6 +1275,8 @@ func (q *Queries) SelectOneApplication(ctx context.Context, applicationID string
 		pq.Array(&i.WhitelistBlockchains),
 		pq.Array(&i.WhitelistOrigins),
 		pq.Array(&i.WhitelistUserAgents),
+		&i.WhitelistContracts,
+		&i.WhitelistMethods,
 		&i.SignedUp,
 		&i.OnQuarter,
 		&i.OnHalf,
@@ -1258,8 +1285,6 @@ func (q *Queries) SelectOneApplication(ctx context.Context, applicationID string
 		&i.CustomLimit,
 		&i.PayPlan,
 		&i.PlanLimit,
-		&i.WhitelistContracts,
-		&i.WhitelistMethods,
 	)
 	return i, err
 }
@@ -1485,6 +1510,74 @@ func (q *Queries) UpdateUserAccess(ctx context.Context, arg UpdateUserAccessPara
 	return err
 }
 
+const updateWhitelistContracts = `-- name: UpdateWhitelistContracts :exec
+WITH new_data (application_id, blockchain_id, contract) AS (
+    SELECT $1 as application_id,
+        $2 as blockchain_id,
+        unnest($3::VARCHAR []) as contract
+),
+deleted_data AS (
+    DELETE FROM whitelist_contracts
+    WHERE application_id = $1
+        AND blockchain_id = $2
+        AND contract NOT IN (
+            SELECT contract
+            FROM new_data
+        )
+    RETURNING id, application_id, blockchain_id, contract
+)
+INSERT INTO whitelist_contracts (application_id, blockchain_id, contract)
+SELECT application_id,
+    blockchain_id,
+    contract
+FROM new_data ON CONFLICT (application_id, blockchain_id, contract) DO NOTHING
+`
+
+type UpdateWhitelistContractsParams struct {
+	ApplicationID string         `json:"applicationID"`
+	BlockchainID  sql.NullString `json:"blockchainID"`
+	Contracts     []string       `json:"contracts"`
+}
+
+func (q *Queries) UpdateWhitelistContracts(ctx context.Context, arg UpdateWhitelistContractsParams) error {
+	_, err := q.db.ExecContext(ctx, updateWhitelistContracts, arg.ApplicationID, arg.BlockchainID, pq.Array(arg.Contracts))
+	return err
+}
+
+const updateWhitelistMethods = `-- name: UpdateWhitelistMethods :exec
+WITH new_data (application_id, blockchain_id, method) AS (
+    SELECT $1 as application_id,
+        $2 as blockchain_id,
+        unnest($3::VARCHAR []) as method
+),
+deleted_data AS (
+    DELETE FROM whitelist_methods
+    WHERE application_id = $1
+        AND blockchain_id = $2
+        AND method NOT IN (
+            SELECT method
+            FROM new_data
+        )
+    RETURNING id, application_id, blockchain_id, method
+)
+INSERT INTO whitelist_methods (application_id, blockchain_id, method)
+SELECT application_id,
+    blockchain_id,
+    method
+FROM new_data ON CONFLICT (application_id, blockchain_id, method) DO NOTHING
+`
+
+type UpdateWhitelistMethodsParams struct {
+	ApplicationID string         `json:"applicationID"`
+	BlockchainID  sql.NullString `json:"blockchainID"`
+	Methods       []string       `json:"methods"`
+}
+
+func (q *Queries) UpdateWhitelistMethods(ctx context.Context, arg UpdateWhitelistMethodsParams) error {
+	_, err := q.db.ExecContext(ctx, updateWhitelistMethods, arg.ApplicationID, arg.BlockchainID, pq.Array(arg.Methods))
+	return err
+}
+
 const upsertAppLimit = `-- name: UpsertAppLimit :exec
 INSERT INTO app_limits AS al (
         application_id,
@@ -1664,61 +1757,5 @@ func (q *Queries) UpsertStickinessOptions(ctx context.Context, arg UpsertStickin
 		arg.Stickiness,
 		pq.Array(arg.Origins),
 	)
-	return err
-}
-
-const upsertWhitelistContracts = `-- name: UpsertWhitelistContracts :exec
-WITH data (application_id, blockchain_id, contracts) AS (
-    VALUES (
-            $1::VARCHAR,
-            $2::VARCHAR,
-            $3::VARCHAR []
-        )
-)
-INSERT INTO whitelist_contracts (application_id, blockchain_id, contracts)
-SELECT application_id,
-    blockchain_id,
-    contracts
-FROM data ON CONFLICT (application_id, blockchain_id) DO
-UPDATE
-SET contracts = excluded.contracts
-`
-
-type UpsertWhitelistContractsParams struct {
-	ApplicationID string   `json:"applicationID"`
-	BlockchainID  string   `json:"blockchainID"`
-	Contracts     []string `json:"contracts"`
-}
-
-func (q *Queries) UpsertWhitelistContracts(ctx context.Context, arg UpsertWhitelistContractsParams) error {
-	_, err := q.db.ExecContext(ctx, upsertWhitelistContracts, arg.ApplicationID, arg.BlockchainID, pq.Array(arg.Contracts))
-	return err
-}
-
-const upsertWhitelistMethods = `-- name: UpsertWhitelistMethods :exec
-WITH data (application_id, blockchain_id, methods) AS (
-    VALUES (
-            $1::VARCHAR,
-            $2::VARCHAR,
-            $3::VARCHAR []
-        )
-)
-INSERT INTO whitelist_methods (application_id, blockchain_id, methods)
-SELECT application_id,
-    blockchain_id,
-    methods::VARCHAR []
-FROM data ON CONFLICT (application_id, blockchain_id) DO
-UPDATE
-SET methods = EXCLUDED.methods
-`
-
-type UpsertWhitelistMethodsParams struct {
-	ApplicationID string   `json:"applicationID"`
-	BlockchainID  string   `json:"blockchainID"`
-	Methods       []string `json:"methods"`
-}
-
-func (q *Queries) UpsertWhitelistMethods(ctx context.Context, arg UpsertWhitelistMethodsParams) error {
-	_, err := q.db.ExecContext(ctx, upsertWhitelistMethods, arg.ApplicationID, arg.BlockchainID, pq.Array(arg.Methods))
 	return err
 }

--- a/postgres-driver/sqlc/query.sql
+++ b/postgres-driver/sqlc/query.sql
@@ -120,13 +120,6 @@ SET active = $2,
     updated_at = $3
 WHERE blockchain_id = $1;
 -- name: SelectApplications :many
-WITH app_whitelists AS (
-    SELECT application_id
-    FROM whitelist_contracts
-    UNION
-    SELECT application_id
-    FROM whitelist_methods
-)
 SELECT a.application_id,
     a.contact_email,
     a.created_at,
@@ -150,6 +143,29 @@ SELECT a.application_id,
     gs.whitelist_blockchains,
     gs.whitelist_origins,
     gs.whitelist_user_agents,
+    CASE
+        WHEN wc.application_id IS NOT NULL THEN json_agg(
+            DISTINCT jsonb_build_object(
+                'blockchainID',
+                wc.blockchain_id,
+                'contracts',
+                wc.contracts
+            )
+        )::VARCHAR
+        ELSE NULL
+    END as whitelist_contracts,
+    CASE
+        WHEN wm.application_id IS NOT NULL THEN json_agg(
+            DISTINCT jsonb_build_object(
+                'blockchainID',
+                wm.blockchain_id,
+                'methods',
+                wm.methods
+            )
+        )::VARCHAR
+        ELSE NULL
+    END as whitelist_methods,
+    ns.signed_up,
     ns.signed_up,
     ns.on_quarter,
     ns.on_half,
@@ -157,49 +173,30 @@ SELECT a.application_id,
     ns.on_full,
     al.custom_limit,
     al.pay_plan,
-    pp.daily_limit as plan_limit,
-    CASE
-        WHEN wc.application_id IS NOT NULL THEN json_agg(
-            json_build_object(
-                'blockchain_id',
-                wc.blockchain_id,
-                'contracts',
-                wc.contracts
-            )
-        )::VARCHAR
-        ELSE null
-    END as whitelist_contracts,
-    CASE
-        WHEN wm.application_id IS NOT NULL THEN json_agg(
-            json_build_object(
-                'blockchain_id',
-                wm.blockchain_id,
-                'methods',
-                wm.methods
-            )
-        )::VARCHAR
-        ELSE null
-    END as whitelist_methods
+    pp.daily_limit as plan_limit
 FROM applications AS a
     LEFT JOIN gateway_aat AS ga ON a.application_id = ga.application_id
     LEFT JOIN gateway_settings AS gs ON a.application_id = gs.application_id
     LEFT JOIN notification_settings AS ns ON a.application_id = ns.application_id
     LEFT JOIN app_limits AS al ON a.application_id = al.application_id
     LEFT JOIN pay_plans AS pp ON al.pay_plan = pp.plan_type
-    LEFT JOIN whitelist_contracts wc ON a.application_id = wc.application_id
-    LEFT JOIN whitelist_methods wm ON a.application_id = wm.application_id
+    LEFT JOIN (
+        SELECT application_id,
+            blockchain_id,
+            json_agg(contract) AS contracts
+        FROM whitelist_contracts
+        GROUP BY application_id,
+            blockchain_id
+    ) wc ON a.application_id = wc.application_id
+    LEFT JOIN (
+        SELECT application_id,
+            blockchain_id,
+            json_agg(method) AS methods
+        FROM whitelist_methods
+        GROUP BY application_id,
+            blockchain_id
+    ) wm ON a.application_id = wm.application_id
 GROUP BY a.application_id,
-    a.contact_email,
-    a.created_at,
-    a.description,
-    a.dummy,
-    a.name,
-    a.owner,
-    a.status,
-    a.updated_at,
-    a.url,
-    a.user_id,
-    a.first_date_surpassed,
     ga.address,
     ga.client_public_key,
     ga.private_key,
@@ -222,13 +219,6 @@ GROUP BY a.application_id,
     wc.application_id,
     wm.application_id;
 -- name: SelectOneApplication :one
-WITH app_whitelists AS (
-    SELECT application_id
-    FROM whitelist_contracts
-    UNION
-    SELECT application_id
-    FROM whitelist_methods
-)
 SELECT a.application_id,
     a.contact_email,
     a.created_at,
@@ -252,6 +242,28 @@ SELECT a.application_id,
     gs.whitelist_blockchains,
     gs.whitelist_origins,
     gs.whitelist_user_agents,
+    CASE
+        WHEN wc.application_id IS NOT NULL THEN json_agg(
+            DISTINCT jsonb_build_object(
+                'blockchainID',
+                wc.blockchain_id,
+                'contracts',
+                wc.contracts
+            )
+        )::VARCHAR
+        ELSE NULL
+    END as whitelist_contracts,
+    CASE
+        WHEN wm.application_id IS NOT NULL THEN json_agg(
+            DISTINCT jsonb_build_object(
+                'blockchainID',
+                wm.blockchain_id,
+                'methods',
+                wm.methods
+            )
+        )::VARCHAR
+        ELSE NULL
+    END as whitelist_methods,
     ns.signed_up,
     ns.on_quarter,
     ns.on_half,
@@ -259,50 +271,31 @@ SELECT a.application_id,
     ns.on_full,
     al.custom_limit,
     al.pay_plan,
-    pp.daily_limit as plan_limit,
-    CASE
-        WHEN wc.application_id IS NOT NULL THEN json_agg(
-            json_build_object(
-                'blockchain_id',
-                wc.blockchain_id,
-                'contracts',
-                wc.contracts
-            )
-        )::VARCHAR
-        ELSE null
-    END as whitelist_contracts,
-    CASE
-        WHEN wm.application_id IS NOT NULL THEN json_agg(
-            json_build_object(
-                'blockchain_id',
-                wm.blockchain_id,
-                'methods',
-                wm.methods
-            )
-        )::VARCHAR
-        ELSE null
-    END as whitelist_methods
+    pp.daily_limit as plan_limit
 FROM applications AS a
     LEFT JOIN gateway_aat AS ga ON a.application_id = ga.application_id
     LEFT JOIN gateway_settings AS gs ON a.application_id = gs.application_id
     LEFT JOIN notification_settings AS ns ON a.application_id = ns.application_id
     LEFT JOIN app_limits AS al ON a.application_id = al.application_id
     LEFT JOIN pay_plans AS pp ON al.pay_plan = pp.plan_type
-    LEFT JOIN whitelist_contracts wc ON a.application_id = wc.application_id
-    LEFT JOIN whitelist_methods wm ON a.application_id = wm.application_id
+    LEFT JOIN (
+        SELECT application_id,
+            blockchain_id,
+            json_agg(contract) AS contracts
+        FROM whitelist_contracts
+        GROUP BY application_id,
+            blockchain_id
+    ) wc ON a.application_id = wc.application_id
+    LEFT JOIN (
+        SELECT application_id,
+            blockchain_id,
+            json_agg(method) AS methods
+        FROM whitelist_methods
+        GROUP BY application_id,
+            blockchain_id
+    ) wm ON a.application_id = wm.application_id
 WHERE a.application_id = $1
 GROUP BY a.application_id,
-    a.contact_email,
-    a.created_at,
-    a.description,
-    a.dummy,
-    a.name,
-    a.owner,
-    a.status,
-    a.updated_at,
-    a.url,
-    a.user_id,
-    a.first_date_surpassed,
     ga.address,
     ga.client_public_key,
     ga.private_key,
@@ -421,11 +414,7 @@ INSERT into gateway_settings (
         secret_key,
         secret_key_required
     )
-VALUES (
-        $1,
-        $2,
-        $3
-    );
+VALUES ($1, $2, $3);
 -- name: InsertNotificationSettings :exec
 INSERT into notification_settings (
         application_id,
@@ -494,36 +483,58 @@ SET secret_key = COALESCE(EXCLUDED.secret_key, gs.secret_key),
         EXCLUDED.whitelist_blockchains,
         gs.whitelist_blockchains
     );
--- name: UpsertWhitelistContracts :exec
-WITH data (application_id, blockchain_id, contracts) AS (
-    VALUES (
-            @application_id::VARCHAR,
-            @blockchain_id::VARCHAR,
-            @contracts::VARCHAR []
+-- name: UpdateWhitelistContracts :exec
+WITH new_data (application_id, blockchain_id, contract) AS (
+    SELECT $1 as application_id,
+        $2 as blockchain_id,
+        unnest(@contracts::VARCHAR []) as contract
+),
+deleted_data AS (
+    DELETE FROM whitelist_contracts
+    WHERE application_id = $1
+        AND blockchain_id = $2
+        AND contract NOT IN (
+            SELECT contract
+            FROM new_data
         )
+    RETURNING *
 )
-INSERT INTO whitelist_contracts (application_id, blockchain_id, contracts)
+INSERT INTO whitelist_contracts (application_id, blockchain_id, contract)
 SELECT application_id,
     blockchain_id,
-    contracts
-FROM data ON CONFLICT (application_id, blockchain_id) DO
-UPDATE
-SET contracts = excluded.contracts;
--- name: UpsertWhitelistMethods :exec
-WITH data (application_id, blockchain_id, methods) AS (
-    VALUES (
-            @application_id::VARCHAR,
-            @blockchain_id::VARCHAR,
-            @methods::VARCHAR []
+    contract
+FROM new_data ON CONFLICT (application_id, blockchain_id, contract) DO NOTHING;
+-- name: DeleteNotPresentWhitelistContracts :exec
+DELETE FROM whitelist_contracts
+WHERE application_id = $1 AND blockchain_id NOT IN (
+   SELECT unnest(@blockchain_ids::VARCHAR[])
+);
+-- name: UpdateWhitelistMethods :exec
+WITH new_data (application_id, blockchain_id, method) AS (
+    SELECT $1 as application_id,
+        $2 as blockchain_id,
+        unnest(@methods::VARCHAR []) as method
+),
+deleted_data AS (
+    DELETE FROM whitelist_methods
+    WHERE application_id = $1
+        AND blockchain_id = $2
+        AND method NOT IN (
+            SELECT method
+            FROM new_data
         )
+    RETURNING *
 )
-INSERT INTO whitelist_methods (application_id, blockchain_id, methods)
+INSERT INTO whitelist_methods (application_id, blockchain_id, method)
 SELECT application_id,
     blockchain_id,
-    methods::VARCHAR []
-FROM data ON CONFLICT (application_id, blockchain_id) DO
-UPDATE
-SET methods = EXCLUDED.methods;
+    method
+FROM new_data ON CONFLICT (application_id, blockchain_id, method) DO NOTHING;
+-- name: DeleteNotPresentWhitelistMethods :exec
+DELETE FROM whitelist_methods
+WHERE application_id = $1 AND blockchain_id NOT IN (
+   SELECT unnest(@blockchain_ids::VARCHAR[])
+);
 -- name: UpsertNotificationSettings :exec
 INSERT INTO notification_settings AS ns (
         application_id,

--- a/postgres-driver/sqlc/schema.sql
+++ b/postgres-driver/sqlc/schema.sql
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS user_access (
 	created_at TIMESTAMP NULL,
 	updated_at TIMESTAMP NULL,
 	PRIMARY KEY (id),
-    UNIQUE (lb_id, user_id),
+	UNIQUE (lb_id, user_id),
 	CONSTRAINT fk_lb FOREIGN KEY(lb_id) REFERENCES loadbalancers(lb_id),
 	CONSTRAINT fk_role FOREIGN KEY(role_name) REFERENCES user_roles(name)
 );
@@ -151,17 +151,17 @@ CREATE TABLE whitelist_contracts (
 	id SERIAL PRIMARY KEY,
 	application_id VARCHAR NOT NULL,
 	blockchain_id VARCHAR,
-	contracts VARCHAR[],
+	contract VARCHAR,
 	CONSTRAINT fk_application FOREIGN KEY(application_id) REFERENCES applications(application_id),
-	UNIQUE(application_id, blockchain_id)
+	UNIQUE(application_id, blockchain_id, contract)
 );
 CREATE TABLE whitelist_methods (
 	id SERIAL PRIMARY KEY,
 	application_id VARCHAR NOT NULL,
 	blockchain_id VARCHAR,
-	methods VARCHAR[],
+	method VARCHAR,
 	CONSTRAINT fk_application FOREIGN KEY(application_id) REFERENCES applications(application_id),
-	UNIQUE(application_id, blockchain_id)
+	UNIQUE(application_id, blockchain_id, method)
 );
 CREATE TABLE IF NOT EXISTS notification_settings (
 	id INT GENERATED ALWAYS AS IDENTITY,

--- a/testdata/seed_test_db.sql
+++ b/testdata/seed_test_db.sql
@@ -81,17 +81,66 @@ VALUES (
 INSERT INTO gateway_settings (
         application_id,
         secret_key,
-        secret_key_required
+        secret_key_required,
+        whitelist_blockchains,
+        whitelist_origins,
+        whitelist_user_agents
     )
 VALUES (
         'test_app_47hfnths73j2se',
         'test_40f482d91a5ef2300ebb4e2308c',
-        true
+        true,
+        '{ "chain_1" }',
+        '{ "origin_1", "origin_2" }',
+        '{ "user_agent_1", "user_agent_2", "user_agent_3" }'
     ),
     (
         'test_app_5hdf7sh23jd828',
         'test_90210ac4bdd3423e24877d1ff92',
-        false
+        false,
+        null,
+        null,
+        null
+    );
+INSERT INTO whitelist_contracts (
+        application_id,
+        blockchain_id,
+        contract
+    )
+VALUES (
+        'test_app_47hfnths73j2se',
+        'TST1',
+        'test_address_12345'
+    ),
+    (
+        'test_app_47hfnths73j2se',
+        'TST2',
+        'test_address_67890'
+    ),
+    (
+        'test_app_47hfnths73j2se',
+        'TST1',
+        'test_address_44444'
+    );
+INSERT INTO whitelist_methods (
+        application_id,
+        blockchain_id,
+        method
+    )
+VALUES (
+        'test_app_47hfnths73j2se',
+        'TST1',
+        'GET'
+    ),
+    (
+        'test_app_47hfnths73j2se',
+        'TST2',
+        'PUT'
+    ),
+    (
+        'test_app_47hfnths73j2se',
+        'TST2',
+        'POST'
     );
 INSERT INTO notification_settings (
         application_id,

--- a/types/application.go
+++ b/types/application.go
@@ -42,24 +42,34 @@ type (
 		Version              string `json:"version"`
 	}
 	GatewaySettings struct {
-		ID                   string              `json:"id,omitempty"`
-		SecretKey            string              `json:"secretKey"`
-		SecretKeyRequired    bool                `json:"secretKeyRequired"`
-		WhitelistOrigins     []string            `json:"whitelistOrigins,omitempty"`
-		WhitelistUserAgents  []string            `json:"whitelistUserAgents,omitempty"`
-		WhitelistContracts   []WhitelistContract `json:"whitelistContracts,omitempty"`
-		WhitelistMethods     []WhitelistMethod   `json:"whitelistMethods,omitempty"`
-		WhitelistBlockchains []string            `json:"whitelistBlockchains,omitempty"`
+		ID                   string               `json:"id,omitempty"`
+		SecretKey            string               `json:"secretKey"`
+		SecretKeyRequired    bool                 `json:"secretKeyRequired"`
+		WhitelistOrigins     []string             `json:"whitelistOrigins,omitempty"`
+		WhitelistUserAgents  []string             `json:"whitelistUserAgents,omitempty"`
+		WhitelistContracts   []WhitelistContracts `json:"whitelistContracts,omitempty"`
+		WhitelistMethods     []WhitelistMethods   `json:"whitelistMethods,omitempty"`
+		WhitelistBlockchains []string             `json:"whitelistBlockchains,omitempty"`
 	}
-	WhitelistContract struct {
+	WhitelistContracts struct {
 		ID           string   `json:"id,omitempty"`
 		BlockchainID string   `json:"blockchainID"`
 		Contracts    []string `json:"contracts"`
 	}
-	WhitelistMethod struct {
+	WhitelistContract struct {
+		ID           string `json:"id,omitempty"`
+		BlockchainID string `json:"blockchainID"`
+		Contract     string `json:"contract"`
+	}
+	WhitelistMethods struct {
 		ID           string   `json:"id,omitempty"`
 		BlockchainID string   `json:"blockchainID"`
 		Methods      []string `json:"methods"`
+	}
+	WhitelistMethod struct {
+		ID           string `json:"id,omitempty"`
+		BlockchainID string `json:"blockchainID"`
+		Method       string `json:"method"`
 	}
 	AppLimit struct {
 		ID          string  `json:"id,omitempty"`
@@ -89,14 +99,14 @@ type (
 		Remove               bool                        `json:"remove,omitempty"`
 	}
 	UpdateGatewaySettings struct {
-		ID                   string              `json:"id,omitempty"`
-		SecretKey            string              `json:"secretKey"`
-		SecretKeyRequired    *bool               `json:"secretKeyRequired"`
-		WhitelistOrigins     []string            `json:"whitelistOrigins,omitempty"`
-		WhitelistUserAgents  []string            `json:"whitelistUserAgents,omitempty"`
-		WhitelistContracts   []WhitelistContract `json:"whitelistContracts,omitempty"`
-		WhitelistMethods     []WhitelistMethod   `json:"whitelistMethods,omitempty"`
-		WhitelistBlockchains []string            `json:"whitelistBlockchains,omitempty"`
+		ID                   string               `json:"id,omitempty"`
+		SecretKey            string               `json:"secretKey"`
+		SecretKeyRequired    *bool                `json:"secretKeyRequired"`
+		WhitelistOrigins     []string             `json:"whitelistOrigins,omitempty"`
+		WhitelistUserAgents  []string             `json:"whitelistUserAgents,omitempty"`
+		WhitelistContracts   []WhitelistContracts `json:"whitelistContracts,omitempty"`
+		WhitelistMethods     []WhitelistMethods   `json:"whitelistMethods,omitempty"`
+		WhitelistBlockchains []string             `json:"whitelistBlockchains,omitempty"`
 	}
 	UpdateFirstDateSurpassed struct {
 		ApplicationIDs     []string  `json:"applicationIDs"`


### PR DESCRIPTION
This includes the fix to store whitelist contracts & methods as single rows in the DB to avoid the issue of Postgres notifications hitting the size limit.