### PR TITLE
fix: updates accept user queries to set user ID

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -37,8 +37,8 @@ type (
 		UpdateLoadBalancer(ctx context.Context, id string, options *types.UpdateLoadBalancer) error
 		/* UpdateUserAccessRole updates the RoleName for a UserAccess row */
 		UpdateUserAccessRole(ctx context.Context, userID, lbID string, roleName types.RoleName) error
-		/* AcceptUserAccess sets the Accepted field to true for a UserAccess row */
-		AcceptUserAccess(ctx context.Context, userID, lbID string) error
+		/* AcceptUserAccess sets the User ID and the Accepted field to true for a UserAccess row */
+		AcceptUserAccess(ctx context.Context, email, userID, lbID string) error
 		/* RemoveLoadBalancer sets the user ID to an empty string (will not appear in Portal API or UI) */
 		RemoveLoadBalancer(ctx context.Context, id string) error
 		/* RemoveUserAccess deletes a UserAccess row */

--- a/driver/mock_driver.go
+++ b/driver/mock_driver.go
@@ -14,13 +14,13 @@ type MockDriver struct {
 	mock.Mock
 }
 
-// AcceptUserAccess provides a mock function with given fields: ctx, userID, lbID
-func (_m *MockDriver) AcceptUserAccess(ctx context.Context, userID string, lbID string) error {
-	ret := _m.Called(ctx, userID, lbID)
+// AcceptUserAccess provides a mock function with given fields: ctx, email, userID, lbID
+func (_m *MockDriver) AcceptUserAccess(ctx context.Context, email string, userID string, lbID string) error {
+	ret := _m.Called(ctx, email, userID, lbID)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, userID, lbID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, email, userID, lbID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/postgres-driver/load_balancer.go
+++ b/postgres-driver/load_balancer.go
@@ -79,7 +79,7 @@ func (p *PostgresDriver) ReadUserPermissions(ctx context.Context) (map[types.Use
 
 	for _, userRoleRow := range userRoles {
 		userID := types.UserID(userRoleRow.UserID.String)
-		lbID := types.LoadBalancerID(userRoleRow.LbID.String)
+		lbID := types.LoadBalancerID(userRoleRow.LbID)
 
 		if userPermissions, ok := userPermissionsMap[userID]; ok {
 			_, err := userPermissions.UpsertPermissions(lbID, userRoleRow.RoleName)
@@ -140,14 +140,10 @@ func (p *PostgresDriver) WriteLoadBalancer(ctx context.Context, loadBalancer *ty
 		}
 	}
 
-	loadBalancer.Users[0].RoleName = types.RoleOwner // The first User will be the initial creater (owner) of the LoadBalancer
-	accepted := true                                 // New LB owners always start with accepted = true
-	userAccessParams := extractInsertUserAccess(id, loadBalancer.Users[0], &accepted, time)
-	if userAccessParams.isNotNull() {
-		err = qtx.InsertUserAccess(ctx, userAccessParams)
-		if err != nil {
-			return nil, err
-		}
+	loadBalancer.Users[0].RoleName = types.RoleOwner                                                // The first User will be the OWNER of the LoadBalancer
+	err = qtx.InsertUserAccess(ctx, extractInsertUserAccess(id, loadBalancer.Users[0], true, time)) // New LB owners always start with accepted = true
+	if err != nil {
+		return nil, err
 	}
 
 	lbAppParams := InsertLbAppsParams{LbID: loadBalancer.ID}
@@ -192,46 +188,35 @@ func (i *InsertStickinessOptionsParams) isNotNull() bool {
 	return i.Duration.Valid || len(i.Origins) > 0 || i.StickyMax.Valid
 }
 
-func extractInsertUserAccess(lbID string, userAccess types.UserAccess, accepted *bool, createdAt time.Time) InsertUserAccessParams {
+func extractInsertUserAccess(lbID string, userAccess types.UserAccess, accepted bool, createdAt time.Time) InsertUserAccessParams {
 	return InsertUserAccessParams{
-		LbID:      newSQLNullString(lbID),
+		LbID:      lbID,
 		UserID:    newSQLNullString(userAccess.UserID),
 		RoleName:  userAccess.RoleName,
-		Email:     newSQLNullString(userAccess.Email),
-		Accepted:  newSQLNullBool(accepted),
+		Email:     userAccess.Email,
+		Accepted:  accepted,
 		CreatedAt: newSQLNullTime(createdAt),
 		UpdatedAt: newSQLNullTime(createdAt),
 	}
-}
-func (i *InsertUserAccessParams) isNotNull() bool {
-	return i.LbID.Valid || i.UserID.Valid || i.Email.Valid
-}
-func (i *InsertUserAccessParams) checkForMissingField() string {
-	if !i.UserID.Valid {
-		return "UserID"
-	}
-	if !i.Email.Valid {
-		return "Email"
-	}
-	return ""
 }
 
 /* WriteLoadBalancerUser saves input LoadBalancer to the database */
 func (p *PostgresDriver) WriteLoadBalancerUser(ctx context.Context, lbID string, userAccess types.UserAccess) error {
 	if lbID == "" {
-		return ErrMissingID
+		return ErrMissingLBID
+	}
+	if userAccess.Email == "" {
+		return ErrMissingEmail
+	}
+	if userAccess.RoleName == types.RoleName("") {
+		return ErrMissingRole
 	}
 	if userAccess.RoleName == types.RoleOwner {
 		return ErrCannotSetToOwner
 	}
 
-	accepted := false // New LB users always start with accepted = false
-	userAccessParams := extractInsertUserAccess(lbID, userAccess, &accepted, time.Now())
-
-	missingField := userAccessParams.checkForMissingField()
-	if missingField != "" {
-		return fmt.Errorf("%w: %s", ErrUserInputIsMissingField, missingField)
-	}
+	userAccess.UserID = ""                                                           // New LB users do not start with their user ID set
+	userAccessParams := extractInsertUserAccess(lbID, userAccess, false, time.Now()) // New LB users always start with accepted = false
 
 	err := p.InsertUserAccess(ctx, userAccessParams)
 	if err != nil {
@@ -303,8 +288,11 @@ func (u *UpsertStickinessOptionsParams) isNotNull() bool {
 
 /* UpdateUserAccessRole updates the RoleName for a UserAccess row */
 func (p *PostgresDriver) UpdateUserAccessRole(ctx context.Context, userID, lbID string, roleName types.RoleName) error {
-	if userID == "" || lbID == "" {
-		return ErrMissingID
+	if userID == "" {
+		return ErrMissingUserID
+	}
+	if lbID == "" {
+		return ErrMissingLBID
 	}
 	if roleName == types.RoleOwner {
 		return ErrCannotSetToOwner
@@ -312,7 +300,7 @@ func (p *PostgresDriver) UpdateUserAccessRole(ctx context.Context, userID, lbID 
 
 	params := UpdateUserAccessParams{
 		UserID:    newSQLNullString(userID),
-		LbID:      newSQLNullString(lbID),
+		LbID:      lbID,
 		RoleName:  roleName,
 		UpdatedAt: newSQLNullTime(time.Now()),
 	}
@@ -325,17 +313,24 @@ func (p *PostgresDriver) UpdateUserAccessRole(ctx context.Context, userID, lbID 
 	return nil
 }
 
-/* AcceptUserAccess sets the Accepted field to true for a UserAccess row */
-func (p *PostgresDriver) AcceptUserAccess(ctx context.Context, userID, lbID string) error {
-	if userID == "" || lbID == "" {
-		return ErrMissingID
+/* AcceptUserAccess sets the User ID and the Accepted field to true for a UserAccess row */
+func (p *PostgresDriver) AcceptUserAccess(ctx context.Context, email, userID, lbID string) error {
+	if email == "" {
+		return ErrMissingEmail
+	}
+	if userID == "" {
+		return ErrMissingUserID
+	}
+	if lbID == "" {
+		return ErrMissingLBID
 	}
 
-	trueBool := true
 	params := SetUserAccessAcceptedParams{
-		UserID:   newSQLNullString(userID),
-		LbID:     newSQLNullString(lbID),
-		Accepted: newSQLNullBool(&trueBool),
+		Email:     email,
+		UserID:    newSQLNullString(userID),
+		LbID:      lbID,
+		Accepted:  true,
+		UpdatedAt: newSQLNullTime(time.Now()),
 	}
 
 	err := p.SetUserAccessAccepted(ctx, params)
@@ -368,7 +363,7 @@ func (p *PostgresDriver) RemoveUserAccess(ctx context.Context, userID, lbID stri
 
 	params := DeleteUserAccessParams{
 		UserID: newSQLNullString(userID),
-		LbID:   newSQLNullString(lbID),
+		LbID:   lbID,
 	}
 
 	err := p.DeleteUserAccess(ctx, params)

--- a/postgres-driver/load_balancer_test.go
+++ b/postgres-driver/load_balancer_test.go
@@ -3,7 +3,6 @@ package postgresdriver
 import (
 	"database/sql"
 	"encoding/json"
-	"fmt"
 
 	"github.com/pokt-foundation/portal-db/types"
 )
@@ -54,7 +53,7 @@ func (ts *PGDriverTestSuite) Test_ReadTests() {
 						},
 						Users: []types.UserAccess{
 							{RoleName: "OWNER", UserID: "test_user_redirect233344", Email: "owner3@test.com", Accepted: true},
-							{RoleName: "MEMBER", UserID: "test_user_member5678", Email: "member2@test.com", Accepted: false},
+							{RoleName: "MEMBER", UserID: "", Email: "member2@test.com", Accepted: false},
 						},
 					},
 					{
@@ -161,15 +160,6 @@ func (ts *PGDriverTestSuite) Test_ReadTests() {
 							"test_lb_34gg4g43g34g5hh": {
 								RoleName:    types.RoleOwner,
 								Permissions: []types.PermissionsEnum{types.ReadEndpoint, types.WriteEndpoint},
-							},
-						},
-					},
-					"test_user_member5678": {
-						UserID: "test_user_member5678",
-						LoadBalancers: map[types.LoadBalancerID]types.LoadBalancerPermissions{
-							"test_lb_34gg4g43g34g5hh": {
-								RoleName:    types.RoleMember,
-								Permissions: []types.PermissionsEnum{types.ReadEndpoint},
 							},
 						},
 					},
@@ -297,11 +287,11 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 				name:      "Should create a new UserAccess row for a LoadBalancer with correct input",
 				lbIDInput: "test_lb_34987u329rfn23f",
 				userInput: types.UserAccess{
-					UserID:   "test_user_47fhsd75jd756sh",
+					UserID:   "",
 					RoleName: types.RoleMember,
 					Email:    "member5@test.com",
 				},
-				expectedUsersJSON: json.RawMessage(`[{"email": "owner1@test.com", "userID": "test_user_1dbffbdfeeb225", "accepted": true, "roleName": "OWNER"}, {"email": "admin1@test.com", "userID": "test_user_admin1234", "accepted": true, "roleName": "ADMIN"}, {"email": "member1@test.com", "userID": "test_user_member1234", "accepted": true, "roleName": "MEMBER"}, {"email": "member5@test.com", "userID": "test_user_47fhsd75jd756sh", "accepted": false, "roleName": "MEMBER"}]`),
+				expectedUsersJSON: json.RawMessage(`[{"email": "owner1@test.com", "userID": "test_user_1dbffbdfeeb225", "accepted": true, "roleName": "OWNER"}, {"email": "admin1@test.com", "userID": "test_user_admin1234", "accepted": true, "roleName": "ADMIN"}, {"email": "member1@test.com", "userID": "test_user_member1234", "accepted": true, "roleName": "MEMBER"}, {"email": "member5@test.com", "userID": null, "accepted": false, "roleName": "MEMBER"}]`),
 				expectedUsers: []types.UserAccess{
 					{
 						UserID:   "test_user_1dbffbdfeeb225",
@@ -322,7 +312,7 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 						Accepted: true,
 					},
 					{
-						UserID:   "test_user_47fhsd75jd756sh",
+						UserID:   "",
 						RoleName: types.RoleMember,
 						Email:    "member5@test.com",
 						Accepted: false,
@@ -331,18 +321,27 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 				err: nil,
 			},
 			{
-				name:      "Should fail if any input fields are null",
+				name:      "Should fail if missing user email",
 				lbIDInput: "test_lb_34987u329rfn23f",
 				userInput: types.UserAccess{
 					UserID:   "test_user_47fhsd75jd756sh",
 					RoleName: types.RoleMember,
 				},
-				err: fmt.Errorf("%w: Email", ErrUserInputIsMissingField),
+				err: ErrMissingEmail,
 			},
 			{
 				name:      "Should fail if lb ID not provided",
 				lbIDInput: "",
-				err:       ErrMissingID,
+				err:       ErrMissingLBID,
+			},
+			{
+				name:      "Should fail if missing user role",
+				lbIDInput: "test_lb_34987u329rfn23f",
+				userInput: types.UserAccess{
+					UserID: "test_user_47fhsd75jd756sh",
+					Email:  "test@test.com",
+				},
+				err: ErrMissingRole,
 			},
 			{
 				name:      "Should fail if attempting to create a User with owner role",
@@ -362,6 +361,7 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 
 			if err == nil {
 				loadBalancer, err := ts.driver.SelectOneLoadBalancer(testCtx, test.lbIDInput)
+
 				ts.Equal(test.err, err)
 				ts.Equal(test.lbIDInput, loadBalancer.LbID)
 				ts.Equal(test.expectedUsersJSON, loadBalancer.Users)
@@ -538,13 +538,13 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 				name:        "Should fail if user ID not provided",
 				lbIDInput:   "test_lb_34gg4g43g34g5hh",
 				userIDInput: "",
-				err:         ErrMissingID,
+				err:         ErrMissingUserID,
 			},
 			{
 				name:        "Should fail if lb ID not provided",
 				lbIDInput:   "",
 				userIDInput: "test_user_member5678",
-				err:         ErrMissingID,
+				err:         ErrMissingLBID,
 			},
 		}
 
@@ -570,16 +570,17 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 
 	ts.Run("Test_AcceptUserAccess", func() {
 		tests := []struct {
-			name                   string
-			lbIDInput, userIDInput string
-			expectedUsersJSON      json.RawMessage
-			expectedUsers          []types.UserAccess
-			err                    error
+			name                                   string
+			userEmailInput, userIDInput, lbIDInput string
+			expectedUsersJSON                      json.RawMessage
+			expectedUsers                          []types.UserAccess
+			err                                    error
 		}{
 			{
-				name:              "Should update the Accepted of a UserAccess row for a LoadBalancer to true",
-				lbIDInput:         "test_lb_34gg4g43g34g5hh",
+				name:              "Should update the User ID and Accepted fields of a UserAccess row for a LoadBalancer once an invitation is accepted by a user",
+				userEmailInput:    "member2@test.com",
 				userIDInput:       "test_user_member5678",
+				lbIDInput:         "test_lb_34gg4g43g34g5hh",
 				expectedUsersJSON: json.RawMessage(`[{"email": "owner3@test.com", "userID": "test_user_redirect233344", "accepted": true, "roleName": "OWNER"}, {"email": "member2@test.com", "userID": "test_user_member5678", "accepted": true, "roleName": "MEMBER"}]`),
 				expectedUsers: []types.UserAccess{
 					{
@@ -598,21 +599,30 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 				err: nil,
 			},
 			{
-				name:        "Should fail if user ID not provided",
-				lbIDInput:   "test_lb_34gg4g43g34g5hh",
-				userIDInput: "",
-				err:         ErrMissingID,
+				name:           "Should fail if user email not provided",
+				userEmailInput: "",
+				lbIDInput:      "test_lb_34gg4g43g34g5hh",
+				userIDInput:    "test_user_member5678",
+				err:            ErrMissingEmail,
 			},
 			{
-				name:        "Should fail if lb ID not provided",
-				lbIDInput:   "",
-				userIDInput: "test_user_member5678",
-				err:         ErrMissingID,
+				name:           "Should fail if user ID not provided",
+				userEmailInput: "test@test.com",
+				lbIDInput:      "test_lb_34gg4g43g34g5hh",
+				userIDInput:    "",
+				err:            ErrMissingUserID,
+			},
+			{
+				name:           "Should fail if lb ID not provided",
+				userEmailInput: "test@test.com",
+				lbIDInput:      "",
+				userIDInput:    "test_user_member5678",
+				err:            ErrMissingLBID,
 			},
 		}
 
 		for _, test := range tests {
-			err := ts.driver.AcceptUserAccess(testCtx, test.userIDInput, test.lbIDInput)
+			err := ts.driver.AcceptUserAccess(testCtx, test.userEmailInput, test.userIDInput, test.lbIDInput)
 			ts.Equal(test.err, err)
 
 			if err == nil {

--- a/postgres-driver/models.generated.go
+++ b/postgres-driver/models.generated.go
@@ -185,11 +185,11 @@ type SyncCheckOption struct {
 
 type UserAccess struct {
 	ID        int32          `json:"id"`
-	LbID      sql.NullString `json:"lbID"`
+	LbID      string         `json:"lbID"`
 	UserID    sql.NullString `json:"userID"`
 	RoleName  types.RoleName `json:"roleName"`
-	Email     sql.NullString `json:"email"`
-	Accepted  sql.NullBool   `json:"accepted"`
+	Email     string         `json:"email"`
+	Accepted  bool           `json:"accepted"`
 	CreatedAt sql.NullTime   `json:"createdAt"`
 	UpdatedAt sql.NullTime   `json:"updatedAt"`
 }

--- a/postgres-driver/postgresdriver.go
+++ b/postgres-driver/postgresdriver.go
@@ -18,7 +18,11 @@ const (
 )
 
 var (
-	ErrMissingID = errors.New("missing id")
+	ErrMissingID     = errors.New("missing id")
+	ErrMissingLBID   = errors.New("missing load balancer id")
+	ErrMissingUserID = errors.New("missing user id")
+	ErrMissingEmail  = errors.New("missing user email")
+	ErrMissingRole   = errors.New("missing user role")
 )
 
 // The PostgresDriver struct satisfies the Driver interface which defines all database driver methods

--- a/postgres-driver/query.sql.generated.go
+++ b/postgres-driver/query.sql.generated.go
@@ -40,7 +40,7 @@ WHERE user_id = $1
 
 type DeleteUserAccessParams struct {
 	UserID sql.NullString `json:"userID"`
-	LbID   sql.NullString `json:"lbID"`
+	LbID   string         `json:"lbID"`
 }
 
 func (q *Queries) DeleteUserAccess(ctx context.Context, arg DeleteUserAccessParams) error {
@@ -496,11 +496,11 @@ VALUES ($1, $2, $3, $4, $5, $6, $7)
 `
 
 type InsertUserAccessParams struct {
-	LbID      sql.NullString `json:"lbID"`
+	LbID      string         `json:"lbID"`
 	RoleName  types.RoleName `json:"roleName"`
 	UserID    sql.NullString `json:"userID"`
-	Email     sql.NullString `json:"email"`
-	Accepted  sql.NullBool   `json:"accepted"`
+	Email     string         `json:"email"`
+	Accepted  bool           `json:"accepted"`
 	CreatedAt sql.NullTime   `json:"createdAt"`
 	UpdatedAt sql.NullTime   `json:"updatedAt"`
 }
@@ -532,11 +532,11 @@ VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (lb_id, user_id) DO NOTHING
 `
 
 type InsertUserAccessNoConflictParams struct {
-	LbID      sql.NullString `json:"lbID"`
+	LbID      string         `json:"lbID"`
 	RoleName  types.RoleName `json:"roleName"`
 	UserID    sql.NullString `json:"userID"`
-	Email     sql.NullString `json:"email"`
-	Accepted  sql.NullBool   `json:"accepted"`
+	Email     string         `json:"email"`
+	Accepted  bool           `json:"accepted"`
 	CreatedAt sql.NullTime   `json:"createdAt"`
 	UpdatedAt sql.NullTime   `json:"updatedAt"`
 }
@@ -1428,10 +1428,12 @@ SELECT ua.lb_id,
     ur.permissions as permissions
 FROM user_access as ua
     LEFT JOIN user_roles AS ur ON ua.role_name = ur.name
+WHERE ua.accepted = true
+    AND ua.user_id IS NOT NULL
 `
 
 type SelectUserRolesRow struct {
-	LbID        sql.NullString          `json:"lbID"`
+	LbID        string                  `json:"lbID"`
 	UserID      sql.NullString          `json:"userID"`
 	RoleName    types.RoleName          `json:"roleName"`
 	Permissions []types.PermissionsEnum `json:"permissions"`
@@ -1467,19 +1469,29 @@ func (q *Queries) SelectUserRoles(ctx context.Context) ([]SelectUserRolesRow, er
 
 const setUserAccessAccepted = `-- name: SetUserAccessAccepted :exec
 UPDATE user_access as ua
-SET accepted = $3
-WHERE ua.user_id = $1
+SET user_id = $3,
+    accepted = $4,
+    updated_at = $5
+WHERE ua.email = $1
     AND ua.lb_id = $2
 `
 
 type SetUserAccessAcceptedParams struct {
-	UserID   sql.NullString `json:"userID"`
-	LbID     sql.NullString `json:"lbID"`
-	Accepted sql.NullBool   `json:"accepted"`
+	Email     string         `json:"email"`
+	LbID      string         `json:"lbID"`
+	UserID    sql.NullString `json:"userID"`
+	Accepted  bool           `json:"accepted"`
+	UpdatedAt sql.NullTime   `json:"updatedAt"`
 }
 
 func (q *Queries) SetUserAccessAccepted(ctx context.Context, arg SetUserAccessAcceptedParams) error {
-	_, err := q.db.ExecContext(ctx, setUserAccessAccepted, arg.UserID, arg.LbID, arg.Accepted)
+	_, err := q.db.ExecContext(ctx, setUserAccessAccepted,
+		arg.Email,
+		arg.LbID,
+		arg.UserID,
+		arg.Accepted,
+		arg.UpdatedAt,
+	)
 	return err
 }
 
@@ -1527,7 +1539,7 @@ WHERE ua.user_id = $1
 
 type UpdateUserAccessParams struct {
 	UserID    sql.NullString `json:"userID"`
-	LbID      sql.NullString `json:"lbID"`
+	LbID      string         `json:"lbID"`
 	RoleName  types.RoleName `json:"roleName"`
 	UpdatedAt sql.NullTime   `json:"updatedAt"`
 }

--- a/postgres-driver/sqlc/query.sql
+++ b/postgres-driver/sqlc/query.sql
@@ -648,7 +648,9 @@ SELECT ua.lb_id,
     ua.role_name,
     ur.permissions as permissions
 FROM user_access as ua
-    LEFT JOIN user_roles AS ur ON ua.role_name = ur.name;
+    LEFT JOIN user_roles AS ur ON ua.role_name = ur.name
+WHERE ua.accepted = true
+    AND ua.user_id IS NOT NULL;
 -- name: InsertLoadBalancer :exec
 INSERT into loadbalancers (
         lb_id,
@@ -709,8 +711,10 @@ WHERE ua.user_id = $1
     AND ua.lb_id = $2;
 -- name: SetUserAccessAccepted :exec
 UPDATE user_access as ua
-SET accepted = $3
-WHERE ua.user_id = $1
+SET user_id = $3,
+    accepted = $4,
+    updated_at = $5
+WHERE ua.email = $1
     AND ua.lb_id = $2;
 -- name: DeleteUserAccess :exec
 DELETE FROM user_access

--- a/postgres-driver/sqlc/schema.sql
+++ b/postgres-driver/sqlc/schema.sql
@@ -86,15 +86,16 @@ CREATE TABLE IF NOT EXISTS stickiness_options (
 );
 CREATE TABLE IF NOT EXISTS user_access (
 	id INT GENERATED ALWAYS AS IDENTITY,
-	lb_id VARCHAR,
-	user_id VARCHAR,
-	role_name VARCHAR,
-	email VARCHAR,
-	accepted BOOLEAN,
+	lb_id VARCHAR NOT NULL,
+	user_id VARCHAR NULL,
+	role_name VARCHAR NOT NULL,
+	email VARCHAR NOT NULL,
+	accepted BOOLEAN NOT NULL,
 	created_at TIMESTAMP NULL,
 	updated_at TIMESTAMP NULL,
 	PRIMARY KEY (id),
 	UNIQUE (lb_id, user_id),
+	UNIQUE (lb_id, email),
 	CONSTRAINT fk_lb FOREIGN KEY(lb_id) REFERENCES loadbalancers(lb_id),
 	CONSTRAINT fk_role FOREIGN KEY(role_name) REFERENCES user_roles(name)
 );

--- a/testdata/seed_test_db.sql
+++ b/testdata/seed_test_db.sql
@@ -237,7 +237,7 @@ VALUES (
     (
         'test_lb_34gg4g43g34g5hh',
         'MEMBER',
-        'test_user_member5678',
+        '',
         'member2@test.com',
         false
     );


### PR DESCRIPTION
Small changes to LB user creation flow:

1. New users do not have user ID set when created
2. When invitation accepted, user ID and accepted field are set based on LB ID and user email.
3. User permissions only appear for users with accepted true and a set user ID