### PR TITLE
fix: change user ID to email in UpdateUserAccess method

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -36,7 +36,7 @@ type (
 		/* UpdateLoadBalancer updates LoadBalancer and related table rows */
 		UpdateLoadBalancer(ctx context.Context, id string, options *types.UpdateLoadBalancer) error
 		/* UpdateUserAccessRole updates the RoleName for a UserAccess row */
-		UpdateUserAccessRole(ctx context.Context, userID, lbID string, roleName types.RoleName) error
+		UpdateUserAccessRole(ctx context.Context, email, lbID string, roleName types.RoleName) error
 		/* AcceptUserAccess sets the User ID and the Accepted field to true for a UserAccess row */
 		AcceptUserAccess(ctx context.Context, email, userID, lbID string) error
 		/* RemoveLoadBalancer sets the user ID to an empty string (will not appear in Portal API or UI) */

--- a/driver/mock_driver.go
+++ b/driver/mock_driver.go
@@ -257,13 +257,13 @@ func (_m *MockDriver) UpdateLoadBalancer(ctx context.Context, id string, options
 	return r0
 }
 
-// UpdateUserAccessRole provides a mock function with given fields: ctx, userID, lbID, roleName
-func (_m *MockDriver) UpdateUserAccessRole(ctx context.Context, userID string, lbID string, roleName types.RoleName) error {
-	ret := _m.Called(ctx, userID, lbID, roleName)
+// UpdateUserAccessRole provides a mock function with given fields: ctx, email, lbID, roleName
+func (_m *MockDriver) UpdateUserAccessRole(ctx context.Context, email string, lbID string, roleName types.RoleName) error {
+	ret := _m.Called(ctx, email, lbID, roleName)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, types.RoleName) error); ok {
-		r0 = rf(ctx, userID, lbID, roleName)
+		r0 = rf(ctx, email, lbID, roleName)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/postgres-driver/load_balancer.go
+++ b/postgres-driver/load_balancer.go
@@ -287,9 +287,9 @@ func (u *UpsertStickinessOptionsParams) isNotNull() bool {
 }
 
 /* UpdateUserAccessRole updates the RoleName for a UserAccess row */
-func (p *PostgresDriver) UpdateUserAccessRole(ctx context.Context, userID, lbID string, roleName types.RoleName) error {
-	if userID == "" {
-		return ErrMissingUserID
+func (p *PostgresDriver) UpdateUserAccessRole(ctx context.Context, email, lbID string, roleName types.RoleName) error {
+	if email == "" {
+		return ErrMissingEmail
 	}
 	if lbID == "" {
 		return ErrMissingLBID
@@ -299,7 +299,7 @@ func (p *PostgresDriver) UpdateUserAccessRole(ctx context.Context, userID, lbID 
 	}
 
 	params := UpdateUserAccessParams{
-		UserID:    newSQLNullString(userID),
+		Email:     email,
 		LbID:      lbID,
 		RoleName:  roleName,
 		UpdatedAt: newSQLNullTime(time.Now()),

--- a/postgres-driver/load_balancer_test.go
+++ b/postgres-driver/load_balancer_test.go
@@ -476,17 +476,17 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 
 	ts.Run("Test_UpdateUserAccessRole", func() {
 		tests := []struct {
-			name                   string
-			lbIDInput, userIDInput string
-			userRoleInput          types.RoleName
-			expectedUsersJSON      json.RawMessage
-			expectedUsers          []types.UserAccess
-			err                    error
+			name                  string
+			lbIDInput, emailInput string
+			userRoleInput         types.RoleName
+			expectedUsersJSON     json.RawMessage
+			expectedUsers         []types.UserAccess
+			err                   error
 		}{
 			{
 				name:              "Should update the RoleName of a UserAccess row for a LoadBalancer with correct input",
 				lbIDInput:         "test_lb_3890ru23jfi32fj",
-				userIDInput:       "test_user_admin5678",
+				emailInput:        "admin2@test.com",
 				userRoleInput:     types.RoleMember,
 				expectedUsersJSON: json.RawMessage(`[{"email": "owner2@test.com", "userID": "test_user_04228205bd261a", "accepted": true, "roleName": "OWNER"}, {"email": "admin2@test.com", "userID": "test_user_admin5678", "accepted": true, "roleName": "MEMBER"}]`),
 				expectedUsers: []types.UserAccess{
@@ -508,7 +508,7 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 			{
 				name:              "Should update the RoleName of a UserAccess row back to the original value for a LoadBalancer with correct input",
 				lbIDInput:         "test_lb_3890ru23jfi32fj",
-				userIDInput:       "test_user_admin5678",
+				emailInput:        "admin2@test.com",
 				userRoleInput:     types.RoleAdmin,
 				expectedUsersJSON: json.RawMessage(`[{"email": "owner2@test.com", "userID": "test_user_04228205bd261a", "accepted": true, "roleName": "OWNER"}, {"email": "admin2@test.com", "userID": "test_user_admin5678", "accepted": true, "roleName": "ADMIN"}]`),
 				expectedUsers: []types.UserAccess{
@@ -530,26 +530,26 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 			{
 				name:          "Should fail if attempting to update User to owner role",
 				lbIDInput:     "test_lb_3890ru23jfi32fj",
-				userIDInput:   "test_user_admin5678",
+				emailInput:    "test_user_admin5678",
 				userRoleInput: types.RoleOwner,
 				err:           ErrCannotSetToOwner,
 			},
 			{
-				name:        "Should fail if user ID not provided",
-				lbIDInput:   "test_lb_34gg4g43g34g5hh",
-				userIDInput: "",
-				err:         ErrMissingUserID,
+				name:       "Should fail if user email not provided",
+				lbIDInput:  "test_lb_34gg4g43g34g5hh",
+				emailInput: "",
+				err:        ErrMissingEmail,
 			},
 			{
-				name:        "Should fail if lb ID not provided",
-				lbIDInput:   "",
-				userIDInput: "test_user_member5678",
-				err:         ErrMissingLBID,
+				name:       "Should fail if lb ID not provided",
+				lbIDInput:  "",
+				emailInput: "test_user_member5678",
+				err:        ErrMissingLBID,
 			},
 		}
 
 		for _, test := range tests {
-			err := ts.driver.UpdateUserAccessRole(testCtx, test.userIDInput, test.lbIDInput, test.userRoleInput)
+			err := ts.driver.UpdateUserAccessRole(testCtx, test.emailInput, test.lbIDInput, test.userRoleInput)
 			ts.Equal(test.err, err)
 
 			if err == nil {

--- a/postgres-driver/models.generated.go
+++ b/postgres-driver/models.generated.go
@@ -207,6 +207,7 @@ type WhitelistContract struct {
 	ApplicationID string         `json:"applicationID"`
 	BlockchainID  sql.NullString `json:"blockchainID"`
 	Contract      sql.NullString `json:"contract"`
+	Contracts     []string       `json:"contracts"`
 }
 
 type WhitelistMethod struct {
@@ -214,4 +215,5 @@ type WhitelistMethod struct {
 	ApplicationID string         `json:"applicationID"`
 	BlockchainID  sql.NullString `json:"blockchainID"`
 	Method        sql.NullString `json:"method"`
+	Methods       []string       `json:"methods"`
 }

--- a/postgres-driver/query.sql.generated.go
+++ b/postgres-driver/query.sql.generated.go
@@ -1562,12 +1562,12 @@ const updateUserAccess = `-- name: UpdateUserAccess :exec
 UPDATE user_access as ua
 SET role_name = COALESCE($3, ua.role_name),
     updated_at = $4
-WHERE ua.user_id = $1
+WHERE ua.email = $1
     AND ua.lb_id = $2
 `
 
 type UpdateUserAccessParams struct {
-	UserID    sql.NullString `json:"userID"`
+	Email     string         `json:"email"`
 	LbID      string         `json:"lbID"`
 	RoleName  types.RoleName `json:"roleName"`
 	UpdatedAt sql.NullTime   `json:"updatedAt"`
@@ -1575,7 +1575,7 @@ type UpdateUserAccessParams struct {
 
 func (q *Queries) UpdateUserAccess(ctx context.Context, arg UpdateUserAccessParams) error {
 	_, err := q.db.ExecContext(ctx, updateUserAccess,
-		arg.UserID,
+		arg.Email,
 		arg.LbID,
 		arg.RoleName,
 		arg.UpdatedAt,
@@ -1597,7 +1597,7 @@ deleted_data AS (
             SELECT contract
             FROM new_data
         )
-    RETURNING id, application_id, blockchain_id, contract
+    RETURNING id, application_id, blockchain_id, contract, contracts
 )
 INSERT INTO whitelist_contracts (application_id, blockchain_id, contract)
 SELECT application_id,
@@ -1631,7 +1631,7 @@ deleted_data AS (
             SELECT method
             FROM new_data
         )
-    RETURNING id, application_id, blockchain_id, method
+    RETURNING id, application_id, blockchain_id, method, methods
 )
 INSERT INTO whitelist_methods (application_id, blockchain_id, method)
 SELECT application_id,

--- a/postgres-driver/sqlc/query.sql
+++ b/postgres-driver/sqlc/query.sql
@@ -722,7 +722,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (lb_id, user_id) DO NOTHING;
 UPDATE user_access as ua
 SET role_name = COALESCE($3, ua.role_name),
     updated_at = $4
-WHERE ua.user_id = $1
+WHERE ua.email = $1
     AND ua.lb_id = $2;
 -- name: SetUserAccessAccepted :exec
 UPDATE user_access as ua


### PR DESCRIPTION
Updates UpdateUserAccess to pass email as param instead of user ID.