### PR TITLE
T-18981 fix: block user from becoming OWNER 

### DIFF
--- a/postgres-driver/load_balancer.go
+++ b/postgres-driver/load_balancer.go
@@ -12,10 +12,11 @@ import (
 )
 
 var (
-	ErrInvalidUsersJSON        = errors.New("error: users JSON is invalid")
-	ErrUserInputIsMissingField = errors.New("error: user access input is missing a required field")
-	ErrLBMustHaveUser          = errors.New("error: a new load balancer must have at least one user")
-	ErrCannotSetToOwner        = errors.New("error: load balancers may only have one owner and the owner role is already set")
+	ErrInvalidUsersJSON            = errors.New("error: users JSON is invalid")
+	ErrUserInputIsMissingField     = errors.New("error: user access input is missing a required field")
+	ErrLBMustHaveUser              = errors.New("error: a new load balancer must have at least one user")
+	ErrCannotSetToOwner            = errors.New("error: load balancers may only have one owner and the owner role is already set")
+	ErrCannotSetToOwnerNotAccepted = errors.New("error: cannot set a user to owner if they have not yet accepted their invitation")
 )
 
 /* ReadLoadBalancers returns all LoadBalancers in the database */
@@ -293,6 +294,16 @@ func (p *PostgresDriver) UpdateUserAccessRole(ctx context.Context, email, lbID s
 	}
 	if lbID == "" {
 		return ErrMissingLBID
+	}
+	// Block setting a user's role to owner if they have not yet accepted their invitation
+	if roleName == types.RoleOwner {
+		accepted, err := p.GetUserAccessAccepted(ctx, GetUserAccessAcceptedParams{Email: email, LbID: lbID})
+		if err != nil {
+			return err
+		}
+		if !accepted {
+			return ErrCannotSetToOwnerNotAccepted
+		}
 	}
 
 	params := UpdateUserAccessParams{

--- a/postgres-driver/load_balancer_test.go
+++ b/postgres-driver/load_balancer_test.go
@@ -582,6 +582,13 @@ func (ts *PGDriverTestSuite) Test_WriteTests() {
 				emailInput: "test_user_member5678",
 				err:        ErrMissingLBID,
 			},
+			{
+				name:          "Should fail if attempting to set user to OWNER and user has not yet accepted their invitation",
+				lbIDInput:     "test_lb_34gg4g43g34g5hh",
+				emailInput:    "member2@test.com",
+				userRoleInput: types.RoleOwner,
+				err:           ErrCannotSetToOwnerNotAccepted,
+			},
 		}
 
 		for _, test := range tests {

--- a/postgres-driver/query.sql.generated.go
+++ b/postgres-driver/query.sql.generated.go
@@ -34,9 +34,10 @@ func (q *Queries) ActivateBlockchain(ctx context.Context, arg ActivateBlockchain
 
 const deleteNotPresentWhitelistContracts = `-- name: DeleteNotPresentWhitelistContracts :exec
 DELETE FROM whitelist_contracts
-WHERE application_id = $1 AND blockchain_id NOT IN (
-   SELECT unnest($2::VARCHAR[])
-)
+WHERE application_id = $1
+    AND blockchain_id NOT IN (
+        SELECT unnest($2::VARCHAR [])
+    )
 `
 
 type DeleteNotPresentWhitelistContractsParams struct {
@@ -51,9 +52,10 @@ func (q *Queries) DeleteNotPresentWhitelistContracts(ctx context.Context, arg De
 
 const deleteNotPresentWhitelistMethods = `-- name: DeleteNotPresentWhitelistMethods :exec
 DELETE FROM whitelist_methods
-WHERE application_id = $1 AND blockchain_id NOT IN (
-   SELECT unnest($2::VARCHAR[])
-)
+WHERE application_id = $1
+    AND blockchain_id NOT IN (
+        SELECT unnest($2::VARCHAR [])
+    )
 `
 
 type DeleteNotPresentWhitelistMethodsParams struct {
@@ -83,7 +85,7 @@ func (q *Queries) DeleteRedirect(ctx context.Context, arg DeleteRedirectParams) 
 }
 
 const deleteUserAccess = `-- name: DeleteUserAccess :exec
-DELETE FROM user_access  as ua
+DELETE FROM user_access as ua
 WHERE ua.email = $1
     AND ua.lb_id = $2
 `
@@ -96,6 +98,25 @@ type DeleteUserAccessParams struct {
 func (q *Queries) DeleteUserAccess(ctx context.Context, arg DeleteUserAccessParams) error {
 	_, err := q.db.ExecContext(ctx, deleteUserAccess, arg.Email, arg.LbID)
 	return err
+}
+
+const getUserAccessAccepted = `-- name: GetUserAccessAccepted :one
+SELECT accepted
+FROM user_access
+WHERE email = $1
+    AND lb_id = $2
+`
+
+type GetUserAccessAcceptedParams struct {
+	Email string `json:"email"`
+	LbID  string `json:"lbID"`
+}
+
+func (q *Queries) GetUserAccessAccepted(ctx context.Context, arg GetUserAccessAcceptedParams) (bool, error) {
+	row := q.db.QueryRowContext(ctx, getUserAccessAccepted, arg.Email, arg.LbID)
+	var accepted bool
+	err := row.Scan(&accepted)
+	return accepted, err
 }
 
 const insertAppLimit = `-- name: InsertAppLimit :exec

--- a/postgres-driver/sqlc/query.sql
+++ b/postgres-driver/sqlc/query.sql
@@ -529,9 +529,10 @@ SELECT application_id,
 FROM new_data ON CONFLICT (application_id, blockchain_id, contract) DO NOTHING;
 -- name: DeleteNotPresentWhitelistContracts :exec
 DELETE FROM whitelist_contracts
-WHERE application_id = $1 AND blockchain_id NOT IN (
-   SELECT unnest(@blockchain_ids::VARCHAR[])
-);
+WHERE application_id = $1
+    AND blockchain_id NOT IN (
+        SELECT unnest(@blockchain_ids::VARCHAR [])
+    );
 -- name: UpdateWhitelistMethods :exec
 WITH new_data (application_id, blockchain_id, method) AS (
     SELECT $1 as application_id,
@@ -555,9 +556,10 @@ SELECT application_id,
 FROM new_data ON CONFLICT (application_id, blockchain_id, method) DO NOTHING;
 -- name: DeleteNotPresentWhitelistMethods :exec
 DELETE FROM whitelist_methods
-WHERE application_id = $1 AND blockchain_id NOT IN (
-   SELECT unnest(@blockchain_ids::VARCHAR[])
-);
+WHERE application_id = $1
+    AND blockchain_id NOT IN (
+        SELECT unnest(@blockchain_ids::VARCHAR [])
+    );
 -- name: UpsertNotificationSettings :exec
 INSERT INTO notification_settings AS ns (
         application_id,
@@ -741,6 +743,11 @@ INSERT INTO user_access (
         updated_at
     )
 VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (lb_id, user_id) DO NOTHING;
+-- name: GetUserAccessAccepted :one
+SELECT accepted
+FROM user_access
+WHERE email = $1
+    AND lb_id = $2;
 -- name: UpdateUserAccess :exec
 UPDATE user_access as ua
 SET role_name = COALESCE($3, ua.role_name),
@@ -755,7 +762,7 @@ SET user_id = $3,
 WHERE ua.email = $1
     AND ua.lb_id = $2;
 -- name: DeleteUserAccess :exec
-DELETE FROM user_access  as ua
+DELETE FROM user_access as ua
 WHERE ua.email = $1
     AND ua.lb_id = $2;
 -- name: UpsertStickinessOptions :exec


### PR DESCRIPTION
Blocks a user from becoming the owner of an endpoint if they haven't yet accepted their invitation (`accepted = false`)