### PR TITLE
fix: fixed bug where empty whitelists would not update

### DIFF
--- a/postgres-driver/application.go
+++ b/postgres-driver/application.go
@@ -326,7 +326,7 @@ func (p *PostgresDriver) UpdateApplication(ctx context.Context, id string, updat
 	}
 
 	gatewaySettingsParams := extractUpsertGatewaySettings(id, update)
-	if gatewaySettingsParams.isNotNull() {
+	if gatewaySettingsParams != nil {
 		err = qtx.UpsertGatewaySettings(ctx, *gatewaySettingsParams)
 		if err != nil {
 			return err
@@ -415,10 +415,6 @@ func extractUpsertGatewaySettings(id string, update *types.UpdateApplication) *U
 		WhitelistUserAgents:  update.GatewaySettings.WhitelistUserAgents,
 		WhitelistBlockchains: update.GatewaySettings.WhitelistBlockchains,
 	}
-}
-func (u *UpsertGatewaySettingsParams) isNotNull() bool {
-	return u != nil && (u.SecretKey.Valid || u.SecretKeyRequired.Valid ||
-		len(u.WhitelistOrigins) != 0 || len(u.WhitelistUserAgents) != 0 || len(u.WhitelistBlockchains) != 0)
 }
 
 func extractUpdateWhitelistContracts(id string, updateContract *types.WhitelistContracts) UpdateWhitelistContractsParams {

--- a/postgres-driver/application_test.go
+++ b/postgres-driver/application_test.go
@@ -320,21 +320,15 @@ func (ts *PGDriverTestSuite) Test_UpdateApplication() {
 			appUpdate: &types.UpdateApplication{
 				Name: "pokt_app_updated_lb",
 				GatewaySettings: &types.UpdateGatewaySettings{
-					WhitelistOrigins:    []string{"test-origin1", "test-origin2"},
-					WhitelistUserAgents: []string{"test-agent1"},
+					WhitelistOrigins:     []string{"test-origin1", "test-origin2"},
+					WhitelistUserAgents:  []string{"test-agent1"},
+					WhitelistBlockchains: []string{"test-chain1"},
 					WhitelistContracts: []types.WhitelistContracts{
-						{
-							BlockchainID: "01",
-							Contracts:    []string{"test-contract1"},
-						},
+						{BlockchainID: "01", Contracts: []string{"test-contract1"}},
 					},
 					WhitelistMethods: []types.WhitelistMethods{
-						{
-							BlockchainID: "01",
-							Methods:      []string{"test-method1"},
-						},
+						{BlockchainID: "01", Methods: []string{"test-method1"}},
 					},
-					WhitelistBlockchains: []string{"test-chain1"},
 				},
 				NotificationSettings: &types.UpdateNotificationSettings{
 					SignedUp:      boolPointer(false),
@@ -352,11 +346,11 @@ func (ts *PGDriverTestSuite) Test_UpdateApplication() {
 			},
 			expectedAfterUpdate: SelectOneApplicationRow{
 				Name:                 sql.NullString{Valid: true, String: "pokt_app_updated_lb"},
+				WhitelistOrigins:     []string{"test-origin1", "test-origin2"},
+				WhitelistUserAgents:  []string{"test-agent1"},
 				WhitelistBlockchains: []string{"test-chain1"},
 				WhitelistContracts:   "[{\"contracts\": [\"test-contract1\"], \"blockchainID\": \"01\"}]",
 				WhitelistMethods:     "[{\"methods\": [\"test-method1\"], \"blockchainID\": \"01\"}]",
-				WhitelistOrigins:     []string{"test-origin1", "test-origin2"},
-				WhitelistUserAgents:  []string{"test-agent1"},
 				SignedUp:             sql.NullBool{Valid: true, Bool: false},
 				OnQuarter:            sql.NullBool{Valid: true, Bool: true},
 				OnHalf:               sql.NullBool{Valid: true, Bool: true},
@@ -384,7 +378,7 @@ func (ts *PGDriverTestSuite) Test_UpdateApplication() {
 			},
 			expectedAfterUpdate: SelectOneApplicationRow{
 				Name:                 sql.NullString{Valid: true, String: "pokt_app_456"},
-				WhitelistBlockchains: []string(nil),
+				WhitelistBlockchains: []string{},
 				WhitelistOrigins:     []string{"test-origin1", "test-origin2"},
 				WhitelistUserAgents:  []string{"test-agent1"},
 				SignedUp:             sql.NullBool{Valid: true, Bool: true},
@@ -402,31 +396,21 @@ func (ts *PGDriverTestSuite) Test_UpdateApplication() {
 			appID: "test_app_5hdf7sh23jd828",
 			appUpdate: &types.UpdateApplication{
 				GatewaySettings: &types.UpdateGatewaySettings{
+					WhitelistOrigins:    []string{"test-origin1", "test-origin2"},
+					WhitelistUserAgents: []string{"test-agent1"},
 					WhitelistContracts: []types.WhitelistContracts{
-						{
-							BlockchainID: "01",
-							Contracts:    []string{"test-contract1", "test-contract2"},
-						},
-						{
-							BlockchainID: "02",
-							Contracts:    []string{"test-contract3", "test-contract4"},
-						},
+						{BlockchainID: "01", Contracts: []string{"test-contract1", "test-contract2"}},
+						{BlockchainID: "02", Contracts: []string{"test-contract3", "test-contract4"}},
 					},
 					WhitelistMethods: []types.WhitelistMethods{
-						{
-							BlockchainID: "01",
-							Methods:      []string{"test-method1", "test-method2", "test-method3"},
-						},
-						{
-							BlockchainID: "03",
-							Methods:      []string{"test-method4", "test-method5", "test-method6"},
-						},
+						{BlockchainID: "01", Methods: []string{"test-method1", "test-method2", "test-method3"}},
+						{BlockchainID: "03", Methods: []string{"test-method4", "test-method5", "test-method6"}},
 					},
 				},
 			},
 			expectedAfterUpdate: SelectOneApplicationRow{
 				Name:                 sql.NullString{Valid: true, String: "pokt_app_456"},
-				WhitelistBlockchains: []string(nil),
+				WhitelistBlockchains: []string{},
 				WhitelistOrigins:     []string{"test-origin1", "test-origin2"},
 				WhitelistUserAgents:  []string{"test-agent1"},
 				WhitelistContracts:   "[{\"contracts\": [\"test-contract1\", \"test-contract2\"], \"blockchainID\": \"01\"}, {\"contracts\": [\"test-contract3\", \"test-contract4\"], \"blockchainID\": \"02\"}]",
@@ -446,35 +430,48 @@ func (ts *PGDriverTestSuite) Test_UpdateApplication() {
 			appID: "test_app_5hdf7sh23jd828",
 			appUpdate: &types.UpdateApplication{
 				GatewaySettings: &types.UpdateGatewaySettings{
+					WhitelistOrigins:    []string{"test-origin1", "test-origin2"},
+					WhitelistUserAgents: []string{"test-agent1"},
 					WhitelistContracts: []types.WhitelistContracts{
-						{
-							BlockchainID: "01",
-							Contracts:    []string{"test-contract2"},
-						},
-						{
-							BlockchainID: "02",
-							Contracts:    []string{},
-						},
+						{BlockchainID: "01", Contracts: []string{"test-contract2"}},
+						{BlockchainID: "02", Contracts: []string{}},
 					},
 					WhitelistMethods: []types.WhitelistMethods{
-						{
-							BlockchainID: "01",
-							Methods:      []string{"test-method1"},
-						},
-						{
-							BlockchainID: "03",
-							Methods:      []string{"test-method5", "test-method6"},
-						},
+						{BlockchainID: "01", Methods: []string{"test-method1"}},
+						{BlockchainID: "03", Methods: []string{"test-method5", "test-method6"}},
 					},
 				},
 			},
 			expectedAfterUpdate: SelectOneApplicationRow{
 				Name:                 sql.NullString{Valid: true, String: "pokt_app_456"},
-				WhitelistBlockchains: []string(nil),
+				WhitelistBlockchains: []string{},
 				WhitelistOrigins:     []string{"test-origin1", "test-origin2"},
 				WhitelistUserAgents:  []string{"test-agent1"},
 				WhitelistContracts:   "[{\"contracts\": [\"test-contract2\"], \"blockchainID\": \"01\"}]",
 				WhitelistMethods:     "[{\"methods\": [\"test-method1\"], \"blockchainID\": \"01\"}, {\"methods\": [\"test-method5\", \"test-method6\"], \"blockchainID\": \"03\"}]",
+				SignedUp:             sql.NullBool{Valid: true, Bool: true},
+				OnQuarter:            sql.NullBool{Valid: true, Bool: false},
+				OnHalf:               sql.NullBool{Valid: true, Bool: false},
+				OnThreeQuarters:      sql.NullBool{Valid: true, Bool: true},
+				OnFull:               sql.NullBool{Valid: true, Bool: false},
+				CustomLimit:          sql.NullInt32{Valid: true, Int32: 0},
+				PayPlan:              sql.NullString{Valid: true, String: "PAY_AS_YOU_GO_V0"},
+			},
+			err: nil,
+		},
+		{
+			name:  "Should remove all whitelist fields",
+			appID: "test_app_5hdf7sh23jd828",
+			appUpdate: &types.UpdateApplication{
+				GatewaySettings: &types.UpdateGatewaySettings{},
+			},
+			expectedAfterUpdate: SelectOneApplicationRow{
+				WhitelistBlockchains: []string{},
+				WhitelistOrigins:     []string{},
+				WhitelistUserAgents:  []string{},
+				WhitelistContracts:   nil,
+				WhitelistMethods:     nil,
+				Name:                 sql.NullString{Valid: true, String: "pokt_app_456"},
 				SignedUp:             sql.NullBool{Valid: true, Bool: true},
 				OnQuarter:            sql.NullBool{Valid: true, Bool: false},
 				OnHalf:               sql.NullBool{Valid: true, Bool: false},

--- a/postgres-driver/query.sql.generated.go
+++ b/postgres-driver/query.sql.generated.go
@@ -1837,14 +1837,14 @@ SET secret_key = COALESCE(EXCLUDED.secret_key, gs.secret_key),
         EXCLUDED.secret_key_required,
         gs.secret_key_required
     ),
-    whitelist_origins = COALESCE(EXCLUDED.whitelist_origins, gs.whitelist_origins),
+    whitelist_origins = COALESCE(EXCLUDED.whitelist_origins, '{}'::text []),
     whitelist_user_agents = COALESCE(
         EXCLUDED.whitelist_user_agents,
-        gs.whitelist_user_agents
+        '{}'::text []
     ),
     whitelist_blockchains = COALESCE(
         EXCLUDED.whitelist_blockchains,
-        gs.whitelist_blockchains
+        '{}'::text []
     )
 `
 

--- a/postgres-driver/sqlc/query.sql
+++ b/postgres-driver/sqlc/query.sql
@@ -497,14 +497,14 @@ SET secret_key = COALESCE(EXCLUDED.secret_key, gs.secret_key),
         EXCLUDED.secret_key_required,
         gs.secret_key_required
     ),
-    whitelist_origins = COALESCE(EXCLUDED.whitelist_origins, gs.whitelist_origins),
+    whitelist_origins = COALESCE(EXCLUDED.whitelist_origins, '{}'::text []),
     whitelist_user_agents = COALESCE(
         EXCLUDED.whitelist_user_agents,
-        gs.whitelist_user_agents
+        '{}'::text []
     ),
     whitelist_blockchains = COALESCE(
         EXCLUDED.whitelist_blockchains,
-        gs.whitelist_blockchains
+        '{}'::text []
     );
 -- name: UpdateWhitelistContracts :exec
 WITH new_data (application_id, blockchain_id, contract) AS (


### PR DESCRIPTION
Found a bug in the DB driver where setting an empty whitelist_origins, user_agents or blockchains would not update due to the nature of the SQL upsert query. This PR fixes that bug.