### PR TITLE
fix: add UpdaterEmail field to UpdateUserAccess struct

### DIFF
--- a/types/load_balancer.go
+++ b/types/load_balancer.go
@@ -63,10 +63,11 @@ type (
 		Stickiness    *bool    `json:"stickiness"`
 	}
 	UpdateUserAccess struct {
-		ID       string   `json:"id,omitempty"`
-		UserID   string   `json:"userID"`
-		Email    string   `json:"email"`
-		RoleName RoleName `json:"roleName"`
+		ID           string   `json:"id,omitempty"`
+		UserID       string   `json:"userID"`
+		Email        string   `json:"email"`
+		UpdaterEmail string   `json:"updaterEmail,omitempty"`
+		RoleName     RoleName `json:"roleName"`
 	}
 
 	RoleName        string


### PR DESCRIPTION
Adds the UpdaterEmail field to the UpdateUserAccess struct.