### PR TITLE
fix: create account user acess when creating new user

### DIFF
--- a/postgres-driver/sqlc/schema.sql
+++ b/postgres-driver/sqlc/schema.sql
@@ -85,13 +85,13 @@ CREATE TABLE account_user_access (
 CREATE UNIQUE INDEX idx_account_owner_constraint ON account_user_access (account_id)
 WHERE role_name = 'OWNER';
 CREATE TABLE IF NOT EXISTS account_integrations (
-	id INT GENERATED ALWAYS AS IDENTITY,
-	account_id VARCHAR(10) NOT NULL UNIQUE REFERENCES accounts(id) ON DELETE CASCADE,
-	covalent_api_key_free VARCHAR UNIQUE,
-	covalent_api_key_paid VARCHAR UNIQUE,
-	created_at TIMESTAMP NULL,
-	updated_at TIMESTAMP NULL,
-	PRIMARY KEY (id)
+    id INT GENERATED ALWAYS AS IDENTITY,
+    account_id VARCHAR(10) NOT NULL UNIQUE REFERENCES accounts(id) ON DELETE CASCADE,
+    covalent_api_key_free VARCHAR UNIQUE,
+    covalent_api_key_paid VARCHAR UNIQUE,
+    created_at TIMESTAMP NULL,
+    updated_at TIMESTAMP NULL,
+    PRIMARY KEY (id)
 );
 -- Chains Tables
 CREATE TABLE chains (
@@ -315,9 +315,9 @@ UPDATE
 CREATE TRIGGER account_integrations_notify_event
 AFTER
 INSERT
-	OR
+    OR
 UPDATE
-	OR DELETE ON account_integrations FOR EACH ROW EXECUTE PROCEDURE notify_event();
+    OR DELETE ON account_integrations FOR EACH ROW EXECUTE PROCEDURE notify_event();
 CREATE TRIGGER users_notify_event
 AFTER
 INSERT

--- a/postgres-driver/user.go
+++ b/postgres-driver/user.go
@@ -137,15 +137,32 @@ func (pg *PostgresDriver) WriteUserNewSignUp(ctx context.Context, user types.Cre
 	}
 	accountID := types.AccountID(id)
 
-	newAccountInput := InsertAccountParams{
+	account, err := qtx.InsertAccount(ctx, InsertAccountParams{
 		ID:        accountID,
 		PlanType:  types.FreetierV0,
 		CreatedAt: createdAt,
 		UpdatedAt: createdAt,
+	})
+	if err != nil {
+		return nil, types.AccountID(""), err
 	}
 
-	account, err := qtx.InsertAccount(ctx, newAccountInput)
+	// New user is Account OWNER
+	owner, err := qtx.InsertAccountUserAccess(ctx, InsertAccountUserAccessParams{
+		AccountID: accountID,
+		UserID:    createdUserID,
+		Email:     user.Email,
+		RoleName:  types.RoleOwner,
+		Accepted:  true,
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
+	})
 	if err != nil {
+		return nil, types.AccountID(""), err
+	}
+
+	var providerUserIDs map[types.AuthType]string
+	if err := json.Unmarshal(owner.ProviderUserIDs, &providerUserIDs); err != nil {
 		return nil, types.AccountID(""), err
 	}
 

--- a/postgres-driver/user_test.go
+++ b/postgres-driver/user_test.go
@@ -115,8 +115,6 @@ func (ts *PGDriverTestSuite) Test_WriteNewUser() {
 
 	for _, test := range tests {
 		ts.Run(test.name, func() {
-			originalAccounts, err := ts.driver.ReadAccounts(context.Background(), types.DriverOptions{})
-			ts.NoError(err)
 			user, accountID, err := ts.driver.WriteUserNewSignUp(context.Background(), test.createUser, testdata.MockTimestamp)
 			ts.Equal(test.err, err)
 
@@ -128,8 +126,18 @@ func (ts *PGDriverTestSuite) Test_WriteNewUser() {
 
 				accounts, err := ts.driver.ReadAccounts(context.Background(), types.DriverOptions{})
 				ts.NoError(err)
-				// if the account was created, ReadAccounts should have 1 more account
-				ts.Equal(len(originalAccounts)+1, len(accounts))
+				exists := false
+				for _, account := range accounts {
+					for _, user := range account.Users {
+						if user.UserID == test.user.ID {
+							exists = true
+							ts.Equal(types.RoleOwner, user.RoleName)
+							ts.Equal(test.createUser.Email, user.Email)
+							break
+						}
+					}
+				}
+				ts.True(exists)
 			}
 		})
 	}


### PR DESCRIPTION
Small change to ensure acount_user_access for the the account OWNER is added when adding a new user sign up.