### PR TITLE
fix: pull plan limit from DB when updating portal app

### DIFF
--- a/legacy-adapters/legacy_adapters.go
+++ b/legacy-adapters/legacy_adapters.go
@@ -433,8 +433,6 @@ func ConvertToV2UpdatePortalApp(u v1Types.UpdateApplication, lbID string) v2Type
 		update.PlanType = v2Types.PayPlanType(u.Limit.PayPlan.Type)
 		if u.Limit.PayPlan.Type == v1Types.Enterprise {
 			update.CustomLimit = int32(u.Limit.CustomLimit)
-		} else {
-			update.DailyLimit = int32(u.Limit.PayPlan.Limit)
 		}
 	}
 

--- a/postgres-driver/portal_app.go
+++ b/postgres-driver/portal_app.go
@@ -360,20 +360,35 @@ func (pg *PostgresDriver) UpdatePortalApp(ctx context.Context, update types.Upda
 
 	qtx := pg.WithTx(tx)
 
-	if update.Name != "" || update.PlanType != "" || update.DailyLimit != 0 || update.CustomLimit != 0 {
+	if update.Name != "" || update.PlanType != "" || update.CustomLimit != 0 {
 		updateApp := UpdatePortalAppFieldsParams{ID: update.AppID, UpdatedAt: newTimestamptz(updatedAt)}
 		if update.Name != "" {
 			updateApp.Name = update.Name
 		}
+
 		if update.PlanType != "" {
 			updateApp.PlanType = string(update.PlanType)
+			// If changing plan, pull the plan daily limit from the DB for non-enterprise plans
+			// TODO remove when change to account-based plan limits completed
+			if update.PlanType != types.Enterprise {
+				dailyLimit, err := qtx.GetPlanDailyLimit(ctx, update.PlanType)
+				if err != nil {
+					switch {
+					case errNoRows(err):
+						return fmt.Errorf(errPayPlanDoesntExist.Error(), update.PlanType)
+					default:
+						return err
+					}
+				}
+
+				updateApp.DailyLimit = newInt4(dailyLimit.Int32, false)
+			}
 		}
-		if update.DailyLimit != 0 {
-			updateApp.DailyLimit = newInt4(update.DailyLimit, false)
-		}
+
 		if update.CustomLimit != 0 {
 			updateApp.CustomLimit = newInt4(update.CustomLimit, false)
 		}
+
 		err := qtx.UpdatePortalAppFields(ctx, updateApp)
 		if err != nil {
 			return err

--- a/postgres-driver/portal_app_test.go
+++ b/postgres-driver/portal_app_test.go
@@ -190,7 +190,6 @@ func (ts *PGDriverTestSuite) Test_UpdatePortalApp() {
 				Notifications: testdata.UpdatePortalAppNotifications,
 				Whitelists:    testdata.UpdatePortalAppWhitelists,
 				PlanType:      testdata.UpdatePortalAppPlan.PlanType,
-				DailyLimit:    testdata.UpdatePortalAppPlan.DailyLimit,
 			},
 			testUpdateTime:  testdata.MockTimestamp,
 			testUpdatedName: "portal-app-updated",
@@ -244,8 +243,8 @@ func (ts *PGDriverTestSuite) Test_UpdatePortalApp() {
 				},
 			},
 			testUpdatedLegacyFields: types.LegacyFields{
-				PlanType:   types.PayAsYouGoV0,
-				DailyLimit: 0,
+				PlanType:   types.FreetierV0,
+				DailyLimit: 250_000,
 			},
 			err: nil,
 		},
@@ -334,21 +333,31 @@ func (ts *PGDriverTestSuite) Test_UpdatePortalApp() {
 		{
 			name: "Should update a new PortalApp in the database with a new plan",
 			updatePortalApp: types.UpdatePortalApp{
-				PlanType:   testdata.UpdatePortalAppPlan.PlanType,
-				DailyLimit: testdata.UpdatePortalAppPlan.DailyLimit,
+				PlanType: testdata.UpdatePortalAppPlan.PlanType,
 			},
 			testUpdateTime: testdata.MockTimestamp,
 			testUpdatedLegacyFields: types.LegacyFields{
-				PlanType:   types.PayAsYouGoV0,
-				DailyLimit: 0,
+				PlanType:   types.FreetierV0,
+				DailyLimit: 250_000,
+			},
+			err: nil,
+		},
+		{
+			name: "Should update a new PortalApp in the database with another new plan",
+			updatePortalApp: types.UpdatePortalApp{
+				PlanType: testdata.UpdatePortalAppPlanTwo.PlanType,
+			},
+			testUpdateTime: testdata.MockTimestamp,
+			testUpdatedLegacyFields: types.LegacyFields{
+				PlanType:   types.TestPlan90k,
+				DailyLimit: 90_000,
 			},
 			err: nil,
 		},
 		{
 			name: "Should update a new PortalApp in the database with an Enterprise plan",
 			updatePortalApp: types.UpdatePortalApp{
-				PlanType:   testdata.UpdatePortalAppEnterprisePlan.PlanType,
-				DailyLimit: testdata.UpdatePortalAppEnterprisePlan.DailyLimit,
+				PlanType: testdata.UpdatePortalAppEnterprisePlan.PlanType,
 			},
 			testUpdateTime: testdata.MockTimestamp,
 			testUpdatedLegacyFields: types.LegacyFields{
@@ -356,6 +365,13 @@ func (ts *PGDriverTestSuite) Test_UpdatePortalApp() {
 				CustomLimit: 5_600_000,
 			},
 			err: nil,
+		},
+		{
+			name: "Should fail if an invalid plan type provided",
+			updatePortalApp: types.UpdatePortalApp{
+				PlanType: types.PayPlanType("what_am_i_doing"),
+			},
+			err: fmt.Errorf(errPayPlanDoesntExist.Error(), "what_am_i_doing"),
 		},
 	}
 
@@ -373,45 +389,49 @@ func (ts *PGDriverTestSuite) Test_UpdatePortalApp() {
 			err = ts.driver.UpdatePortalApp(context.Background(), updateApp, test.testUpdateTime)
 			ts.Equal(test.err, err)
 
-			// Get all portal apps from DB
-			portalApps, err := ts.driver.ReadPortalApps(context.Background(), types.DriverOptions{})
-			ts.Equal(test.err, err)
-			updatedPortalApp, ok := portalApps[createdPortalApp.ID]
-			ts.True(ok)
+			if test.err == nil {
+				// Get all portal apps from DB
+				portalApps, err := ts.driver.ReadPortalApps(context.Background(), types.DriverOptions{})
+				ts.NoError(err)
+				updatedPortalApp, ok := portalApps[createdPortalApp.ID]
+				ts.True(ok)
 
-			// Check update changes
-			if test.testUpdatedName != "" {
-				ts.Equal(test.testUpdatedName, updatedPortalApp.Name)
-			} else {
-				ts.Equal(createdPortalApp.Name, updatedPortalApp.Name)
-			}
+				// Check update changes
+				if test.testUpdatedName != "" {
+					ts.Equal(test.testUpdatedName, updatedPortalApp.Name)
+				} else {
+					ts.Equal(createdPortalApp.Name, updatedPortalApp.Name)
+				}
 
-			if test.testUpdatedSettings.Environment != "" {
-				ts.Equal(test.testUpdatedWhitelists, updatedPortalApp.Whitelists)
-			} else {
-				ts.Equal(createdPortalApp.Settings, updatedPortalApp.Settings)
-			}
+				if test.testUpdatedSettings.Environment != "" {
+					ts.Equal(test.testUpdatedWhitelists, updatedPortalApp.Whitelists)
+				} else {
+					ts.Equal(createdPortalApp.Settings, updatedPortalApp.Settings)
+				}
 
-			if len(test.testUpdatedNotifications) != 0 {
-				ts.Equal(test.testUpdatedNotifications, updatedPortalApp.Notifications)
-			} else {
-				ts.Equal(createdPortalApp.Notifications, updatedPortalApp.Notifications)
-			}
+				if len(test.testUpdatedNotifications) != 0 {
+					ts.Equal(test.testUpdatedNotifications, updatedPortalApp.Notifications)
+				} else {
+					ts.Equal(createdPortalApp.Notifications, updatedPortalApp.Notifications)
+				}
 
-			if len(test.testUpdatedWhitelists.Origins) != 0 {
-				ts.Equal(test.testUpdatedWhitelists, updatedPortalApp.Whitelists)
-			} else {
-				ts.Equal(createdPortalApp.Whitelists, updatedPortalApp.Whitelists)
-			}
+				if len(test.testUpdatedWhitelists.Origins) != 0 {
+					ts.Equal(test.testUpdatedWhitelists, updatedPortalApp.Whitelists)
+				} else {
+					ts.Equal(createdPortalApp.Whitelists, updatedPortalApp.Whitelists)
+				}
 
-			if test.updatePortalApp.PlanType != "" {
-				ts.Equal(test.testUpdatedLegacyFields.PlanType, updatedPortalApp.LegacyFields.PlanType)
-			}
-			if test.updatePortalApp.DailyLimit != 0 {
-				ts.Equal(test.testUpdatedLegacyFields.DailyLimit, updatedPortalApp.LegacyFields.DailyLimit)
-			}
-			if test.updatePortalApp.CustomLimit != 0 {
-				ts.Equal(test.testUpdatedLegacyFields.CustomLimit, updatedPortalApp.LegacyFields.CustomLimit)
+				if test.updatePortalApp.PlanType != "" {
+					ts.Equal(test.testUpdatedLegacyFields.PlanType, updatedPortalApp.LegacyFields.PlanType)
+					if test.updatePortalApp.PlanType != types.Enterprise {
+						dailyLimit, err := ts.driver.GetPlanDailyLimit(context.Background(), test.testUpdatedLegacyFields.PlanType)
+						ts.NoError(err)
+						ts.Equal(test.testUpdatedLegacyFields.DailyLimit, dailyLimit.Int32)
+					}
+				}
+				if test.updatePortalApp.CustomLimit != 0 {
+					ts.Equal(test.testUpdatedLegacyFields.CustomLimit, updatedPortalApp.LegacyFields.CustomLimit)
+				}
 			}
 		})
 	}

--- a/postgres-driver/query.sql.generated.go
+++ b/postgres-driver/query.sql.generated.go
@@ -548,6 +548,19 @@ func (q *Queries) GetLastCreatedUserID(ctx context.Context) (types.UserID, error
 	return id, err
 }
 
+const getPlanDailyLimit = `-- name: GetPlanDailyLimit :one
+SELECT daily_limit
+FROM pay_plans
+WHERE plan_type = $1
+`
+
+func (q *Queries) GetPlanDailyLimit(ctx context.Context, planType types.PayPlanType) (pgtype.Int4, error) {
+	row := q.db.QueryRow(ctx, getPlanDailyLimit, planType)
+	var daily_limit pgtype.Int4
+	err := row.Scan(&daily_limit)
+	return daily_limit, err
+}
+
 const getPortalUserID = `-- name: GetPortalUserID :one
 SELECT user_id
 FROM user_auth_providers

--- a/postgres-driver/sqlc/query.sql
+++ b/postgres-driver/sqlc/query.sql
@@ -208,6 +208,10 @@ SET name = COALESCE(NULLIF(@name::VARCHAR, ''), name),
     custom_limit = COALESCE($3, custom_limit),
     updated_at = $4
 WHERE id = $1;
+-- name: GetPlanDailyLimit :one
+SELECT daily_limit
+FROM pay_plans
+WHERE plan_type = $1;
 -- name: UpdatePortalAppSettings :exec
 UPDATE portal_application_settings
 SET secret_key = COALESCE($2, secret_key),

--- a/testdata/test_db_data.go
+++ b/testdata/test_db_data.go
@@ -1308,8 +1308,10 @@ var (
 		},
 	}
 	UpdatePortalAppPlan = &types.LegacyFields{
-		PlanType:   types.PayAsYouGoV0,
-		DailyLimit: 0,
+		PlanType: types.FreetierV0,
+	}
+	UpdatePortalAppPlanTwo = &types.LegacyFields{
+		PlanType: types.TestPlan90k,
 	}
 	UpdatePortalAppEnterprisePlan = &types.LegacyFields{
 		PlanType:    types.Enterprise,
@@ -1644,8 +1646,7 @@ var (
 				},
 			},
 		},
-		PlanType:   "FREETIER_V0",
-		DailyLimit: 250_000,
+		PlanType: "FREETIER_V0",
 	}
 
 	LegacyUpdateBlockchain = v1Types.UpdateBlockchain{

--- a/types/portal_app.go
+++ b/types/portal_app.go
@@ -203,7 +203,6 @@ type (
 		Whitelists    *WhitelistsObject        `json:"whitelists,omitempty"`
 		// TODO - remove when v2 migration finished
 		PlanType    PayPlanType `json:"planType,omitempty"`
-		DailyLimit  int32       `json:"dailyLimit,omitempty"`
 		CustomLimit int32       `json:"customLimit,omitempty"`
 	}
 


### PR DESCRIPTION
fixes an issue where the update portal app method expected the plan type by pulling the value from the DB instead of taking it as a update struct field.